### PR TITLE
Submit mappings synchronously (GSI-2175)

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -12,4 +12,3 @@ audit_record_type: audit_record_logged
 work_order_signing_key: "{}"
 file_upload_box_topic: file-upload-boxes
 research_data_upload_box_topic: research-data-upload-boxes
-accession_map_topic: accession-maps

--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -9,6 +9,6 @@ ucs_url: http://127.0.0.1/upload
 accession_url: http://127.0.0.1/accession
 audit_record_topic: audit-records
 audit_record_type: audit_record_logged
-jwt_signing_key: "{}"
+work_order_signing_key: "{}"
 file_upload_box_topic: file-upload-boxes
 research_data_upload_box_topic: research-data-upload-boxes

--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -9,6 +9,6 @@ ucs_url: http://127.0.0.1/upload
 accession_url: http://127.0.0.1/accession
 audit_record_topic: audit-records
 audit_record_type: audit_record_logged
-work_order_signing_key: "{}"
+jwt_signing_key: "{}"
 file_upload_box_topic: file-upload-boxes
 research_data_upload_box_topic: research-data-upload-boxes

--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -4,8 +4,9 @@ mongo_dsn: mongodb://localhost:27017
 db_name: uos
 mongo_timeout: 300
 auth_key: "{}"
-ucs_url: http://127.0.0.1/upload
 access_url: http://127.0.0.1/access
+ucs_url: http://127.0.0.1/upload
+accession_url: http://127.0.0.1/accession
 audit_record_topic: audit-records
 audit_record_type: audit_record_logged
 work_order_signing_key: "{}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,8 +31,8 @@ jobs:
 
       - name: Upload coverage to coveralls
         id: coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pip install --upgrade coveralls
-          coveralls --service=github
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.xml
+          fail-on-error: false

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The service requires the following configuration parameters:
   "audit_record_logged"
   ```
 
-- <a id="properties/jwt_signing_key"></a>**`jwt_signing_key`** *(string, format: password, required and write-only)*: The private key for signing work order tokens and other JWTs.
+- <a id="properties/work_order_signing_key"></a>**`work_order_signing_key`** *(string, format: password, required and write-only)*: The private key for signing work order tokens and other JWTs.
 
   Examples:
   ```json

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ The service requires the following configuration parameters:
   "audit_record_logged"
   ```
 
+- <a id="properties/jwt_signing_key"></a>**`jwt_signing_key`** *(string, format: password, required and write-only)*: The private key for signing work order tokens and other JWTs.
+
+  Examples:
+  ```json
+  "{\"crv\": \"P-256\", \"kty\": \"EC\", \"x\": \"...\", \"y\": \"...\"}"
+  ```
+
 - <a id="properties/accession_url"></a>**`accession_url`** *(string, format: uri, required)*: URL pointing to the API of the service that manages accession numbers. Length must be between 1 and 2083 (inclusive).
 
   Examples:
@@ -88,25 +95,11 @@ The service requires the following configuration parameters:
   "http://127.0.0.1/accessions"
   ```
 
-- <a id="properties/jwt_signing_key"></a>**`jwt_signing_key`** *(string, format: password, required and write-only)*: The UOS's private JWK for signing JWT auth tokens.
-
-  Examples:
-  ```json
-  "{\"crv\": \"P-256\", \"kty\": \"EC\", \"x\": \"...\", \"y\": \"...\", \"d\": \"...\"}"
-  ```
-
 - <a id="properties/ucs_url"></a>**`ucs_url`** *(string, format: uri, required)*: URL pointing to the API of the service that owns FileUploadBoxes (currently the UCS). Length must be between 1 and 2083 (inclusive).
 
   Examples:
   ```json
   "http://127.0.0.1/upload"
-  ```
-
-- <a id="properties/jwt_signing_key"></a>**`jwt_signing_key`** *(string, format: password, required and write-only)*: The private key for signing work order tokens.
-
-  Examples:
-  ```json
-  "{\"crv\": \"P-256\", \"kty\": \"EC\", \"x\": \"...\", \"y\": \"...\"}"
   ```
 
 - <a id="properties/access_url"></a>**`access_url`** *(string, format: uri, required)*: URL pointing to the internal access API. Length must be between 1 and 2083 (inclusive).

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The service requires the following configuration parameters:
   "{\"crv\": \"P-256\", \"kty\": \"EC\", \"x\": \"...\", \"y\": \"...\"}"
   ```
 
-- <a id="properties/accession_url"></a>**`accession_url`** *(string, format: uri, required)*: URL pointing to the API of the service that manages accession numbers. Length must be between 1 and 2083 (inclusive).
+- <a id="properties/accession_url"></a>**`accession_url`** *(string, format: uri, required)*: URL pointing to the API of the service that manages accession numbers (currently the study registry service). Length must be between 1 and 2083 (inclusive).
 
   Examples:
   ```json

--- a/README.md
+++ b/README.md
@@ -56,17 +56,6 @@ The service requires the following configuration parameters:
   "research-data-upload-boxes"
   ```
 
-- <a id="properties/accession_map_topic"></a>**`accession_map_topic`** *(string, required)*: The name of the topic used for file accession map outbox events.
-
-  Examples:
-  ```json
-  "accession-maps"
-  ```
-
-  ```json
-  "file-accession-maps"
-  ```
-
 - <a id="properties/file_upload_box_topic"></a>**`file_upload_box_topic`** *(string, required)*: Topic containing published FileUploadBox outbox events.
 
   Examples:

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ The service requires the following configuration parameters:
   "http://127.0.0.1/accessions"
   ```
 
+- <a id="properties/jwt_signing_key"></a>**`jwt_signing_key`** *(string, format: password, required and write-only)*: The UOS's private JWK for signing JWT auth tokens.
+
+  Examples:
+  ```json
+  "{\"crv\": \"P-256\", \"kty\": \"EC\", \"x\": \"...\", \"y\": \"...\", \"d\": \"...\"}"
+  ```
+
 - <a id="properties/ucs_url"></a>**`ucs_url`** *(string, format: uri, required)*: URL pointing to the API of the service that owns FileUploadBoxes (currently the UCS). Length must be between 1 and 2083 (inclusive).
 
   Examples:
@@ -95,7 +102,7 @@ The service requires the following configuration parameters:
   "http://127.0.0.1/upload"
   ```
 
-- <a id="properties/work_order_signing_key"></a>**`work_order_signing_key`** *(string, format: password, required and write-only)*: The private key for signing work order tokens.
+- <a id="properties/jwt_signing_key"></a>**`jwt_signing_key`** *(string, format: password, required and write-only)*: The private key for signing work order tokens.
 
   Examples:
   ```json

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ The service requires the following configuration parameters:
   "audit_record_logged"
   ```
 
+- <a id="properties/accession_url"></a>**`accession_url`** *(string, format: uri, required)*: URL pointing to the API of the service that manages accession numbers. Length must be between 1 and 2083 (inclusive).
+
+  Examples:
+  ```json
+  "http://127.0.0.1/accessions"
+  ```
+
 - <a id="properties/ucs_url"></a>**`ucs_url`** *(string, format: uri, required)*: URL pointing to the API of the service that owns FileUploadBoxes (currently the UCS). Length must be between 1 and 2083 (inclusive).
 
   Examples:

--- a/config_schema.json
+++ b/config_schema.json
@@ -35,7 +35,7 @@
       "title": "Audit Record Type",
       "type": "string"
     },
-    "jwt_signing_key": {
+    "work_order_signing_key": {
       "description": "The private key for signing work order tokens and other JWTs",
       "examples": [
         "{\"crv\": \"P-256\", \"kty\": \"EC\", \"x\": \"...\", \"y\": \"...\"}"
@@ -522,7 +522,7 @@
     "file_upload_box_topic",
     "audit_record_topic",
     "audit_record_type",
-    "jwt_signing_key",
+    "work_order_signing_key",
     "accession_url",
     "ucs_url",
     "access_url",

--- a/config_schema.json
+++ b/config_schema.json
@@ -41,12 +41,12 @@
         "{\"crv\": \"P-256\", \"kty\": \"EC\", \"x\": \"...\", \"y\": \"...\"}"
       ],
       "format": "password",
-      "title": "Jwt Signing Key",
+      "title": "Work Order Signing Key",
       "type": "string",
       "writeOnly": true
     },
     "accession_url": {
-      "description": "URL pointing to the API of the service that manages accession numbers.",
+      "description": "URL pointing to the API of the service that manages accession numbers (currently the study registry service).",
       "examples": [
         "http://127.0.0.1/accessions"
       ],

--- a/config_schema.json
+++ b/config_schema.json
@@ -10,15 +10,6 @@
       "title": "Research Data Upload Box Topic",
       "type": "string"
     },
-    "accession_map_topic": {
-      "description": "The name of the topic used for file accession map outbox events",
-      "examples": [
-        "accession-maps",
-        "file-accession-maps"
-      ],
-      "title": "Accession Map Topic",
-      "type": "string"
-    },
     "file_upload_box_topic": {
       "description": "Topic containing published FileUploadBox outbox events",
       "examples": [
@@ -528,7 +519,6 @@
   },
   "required": [
     "research_data_upload_box_topic",
-    "accession_map_topic",
     "file_upload_box_topic",
     "audit_record_topic",
     "audit_record_type",

--- a/config_schema.json
+++ b/config_schema.json
@@ -44,6 +44,17 @@
       "title": "Audit Record Type",
       "type": "string"
     },
+    "accession_url": {
+      "description": "URL pointing to the API of the service that manages accession numbers.",
+      "examples": [
+        "http://127.0.0.1/accessions"
+      ],
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "title": "Accession Url",
+      "type": "string"
+    },
     "ucs_url": {
       "description": "URL pointing to the API of the service that owns FileUploadBoxes (currently the UCS).",
       "examples": [
@@ -521,6 +532,7 @@
     "file_upload_box_topic",
     "audit_record_topic",
     "audit_record_type",
+    "accession_url",
     "ucs_url",
     "work_order_signing_key",
     "access_url",

--- a/config_schema.json
+++ b/config_schema.json
@@ -35,6 +35,16 @@
       "title": "Audit Record Type",
       "type": "string"
     },
+    "jwt_signing_key": {
+      "description": "The private key for signing work order tokens and other JWTs",
+      "examples": [
+        "{\"crv\": \"P-256\", \"kty\": \"EC\", \"x\": \"...\", \"y\": \"...\"}"
+      ],
+      "format": "password",
+      "title": "Jwt Signing Key",
+      "type": "string",
+      "writeOnly": true
+    },
     "accession_url": {
       "description": "URL pointing to the API of the service that manages accession numbers.",
       "examples": [
@@ -56,16 +66,6 @@
       "minLength": 1,
       "title": "Ucs Url",
       "type": "string"
-    },
-    "work_order_signing_key": {
-      "description": "The private key for signing work order tokens",
-      "examples": [
-        "{\"crv\": \"P-256\", \"kty\": \"EC\", \"x\": \"...\", \"y\": \"...\"}"
-      ],
-      "format": "password",
-      "title": "Work Order Signing Key",
-      "type": "string",
-      "writeOnly": true
     },
     "access_url": {
       "description": "URL pointing to the internal access API.",
@@ -522,9 +522,9 @@
     "file_upload_box_topic",
     "audit_record_topic",
     "audit_record_type",
+    "jwt_signing_key",
     "accession_url",
     "ucs_url",
-    "work_order_signing_key",
     "access_url",
     "service_instance_id",
     "kafka_servers",

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -25,7 +25,6 @@ enable_opentelemetry: false
 file_upload_box_topic: file-upload-boxes
 generate_correlation_id: true
 host: 127.0.0.1
-work_order_signing_key: '**********'
 kafka_compression_type: null
 kafka_dlq_topic: dlq
 kafka_enable_dlq: false
@@ -52,4 +51,5 @@ service_instance_id: '1'
 service_name: uos
 timeout_keep_alive: 90
 ucs_url: http://127.0.0.1/upload
+work_order_signing_key: '**********'
 workers: 1

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -25,7 +25,7 @@ enable_opentelemetry: false
 file_upload_box_topic: file-upload-boxes
 generate_correlation_id: true
 host: 127.0.0.1
-jwt_signing_key: '**********'
+work_order_signing_key: '**********'
 kafka_compression_type: null
 kafka_dlq_topic: dlq
 kafka_enable_dlq: false

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -25,6 +25,7 @@ enable_opentelemetry: false
 file_upload_box_topic: file-upload-boxes
 generate_correlation_id: true
 host: 127.0.0.1
+jwt_signing_key: '**********'
 kafka_compression_type: null
 kafka_dlq_topic: dlq
 kafka_enable_dlq: false
@@ -51,5 +52,4 @@ service_instance_id: '1'
 service_name: uos
 timeout_keep_alive: 90
 ucs_url: http://127.0.0.1/upload
-work_order_signing_key: '**********'
 workers: 1

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,5 +1,4 @@
 access_url: http://127.0.0.1/access
-accession_map_topic: accession-maps
 accession_url: http://127.0.0.1/accession
 api_root_path: ''
 audit_record_topic: audit-records

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,5 +1,6 @@
 access_url: http://127.0.0.1/access
 accession_map_topic: accession-maps
+accession_url: http://127.0.0.1/accession
 api_root_path: ''
 audit_record_topic: audit-records
 audit_record_type: audit_record_logged

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,6 +11,10 @@ components:
               type: string
           title: Mapping
           type: object
+        study_pid:
+          description: Identifier of the study to which the file accessions belong.
+          title: Study Pid
+          type: string
         version:
           description: A counter indicating research data upload box version
           title: Version
@@ -18,6 +22,7 @@ components:
       required:
       - version
       - mapping
+      - study_pid
       title: AccessionMapRequest
       type: object
     BoxRetrievalResults:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13,6 +13,8 @@ components:
           type: object
         study_pid:
           description: Identifier of the study to which the file accessions belong.
+          maxLength: 256
+          minLength: 1
           title: Study Pid
           type: string
         version:

--- a/src/uos/adapters/inbound/fastapi_/routes.py
+++ b/src/uos/adapters/inbound/fastapi_/routes.py
@@ -451,7 +451,9 @@ async def submit_accession_map(
 ) -> None:
     """Update a ResearchDataUploadBox."""
     try:
-        await upload_service.update_accession_map(box_id=box_id, request=request)
+        await upload_service.update_accession_map(
+            box_id=box_id, request=request, user_id=UUID(auth_context.id)
+        )
     except UploadOrchestratorPort.AccessionMapError as err:
         raise HTTPException(status_code=400, detail=str(err)) from err
     except UploadOrchestratorPort.BoxNotFoundError as err:

--- a/src/uos/adapters/outbound/dao.py
+++ b/src/uos/adapters/outbound/dao.py
@@ -18,7 +18,6 @@ from ghga_event_schemas.configs import ResearchDataUploadBoxEventsConfig
 from hexkit.protocols.dao import DaoFactoryProtocol
 from hexkit.protocols.daopub import DaoPublisherFactoryProtocol
 from hexkit.providers.mongodb import MongoDbIndex
-from pydantic import Field
 
 from uos.constants import ACCESSION_MAPS_COLLECTION, BOX_COLLECTION
 from uos.core.models import AccessionMap, ResearchDataUploadBox
@@ -29,12 +28,6 @@ __all__ = ["OutboxPubConfig", "get_accession_map_dao", "get_box_dao"]
 
 class OutboxPubConfig(ResearchDataUploadBoxEventsConfig):
     """Config needed to publish outbox events"""
-
-    accession_map_topic: str = Field(
-        default=...,
-        description="The name of the topic used for file accession map outbox events",
-        examples=["accession-maps", "file-accession-maps"],
-    )
 
 
 async def get_box_dao(

--- a/src/uos/adapters/outbound/dao.py
+++ b/src/uos/adapters/outbound/dao.py
@@ -15,6 +15,7 @@
 """DAO implementation"""
 
 from ghga_event_schemas.configs import ResearchDataUploadBoxEventsConfig
+from hexkit.protocols.dao import DaoFactoryProtocol
 from hexkit.protocols.daopub import DaoPublisherFactoryProtocol
 from hexkit.providers.mongodb import MongoDbIndex
 from pydantic import Field
@@ -54,15 +55,10 @@ async def get_box_dao(
     )
 
 
-async def get_accession_map_dao(
-    *, config: OutboxPubConfig, dao_publisher_factory: DaoPublisherFactoryProtocol
-) -> AccessionMapDao:
-    """Construct an AccessionMap outbox DAO from the provided dao_publisher_factory."""
-    return await dao_publisher_factory.get_dao(
+async def get_accession_map_dao(*, dao_factory: DaoFactoryProtocol) -> AccessionMapDao:
+    """Construct an AccessionMap DAO from the provided dao_factory."""
+    return await dao_factory.get_dao(
         name=ACCESSION_MAPS_COLLECTION,
         dto_model=AccessionMap,
         id_field="box_id",
-        dto_to_event=lambda dto: dto.mapping,
-        event_topic=config.accession_map_topic,
-        autopublish=True,
     )

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -512,3 +512,5 @@ class AccessionClient(AccessionClientPort):
                 },
             )
             raise self.OperationError("Failed to submit accession map.")
+        else:
+            log.info("Submitted accession map for box %s.", accession_map.box_id)

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -27,6 +27,7 @@ from pydantic_settings import BaseSettings
 
 from uos.constants import HTTPX_TIMEOUT
 from uos.core.models import (
+    AccessionMap,
     BaseWorkOrderToken,
     ChangeFileBoxWorkOrder,
     CreateFileBoxWorkOrder,
@@ -35,7 +36,11 @@ from uos.core.models import (
     ViewFileBoxWorkOrder,
 )
 from uos.core.tokens import sign_work_order_token
-from uos.ports.outbound.http import AccessClientPort, FileBoxClientPort
+from uos.ports.outbound.http import (
+    AccessClientPort,
+    AccessionClientPort,
+    FileBoxClientPort,
+)
 
 log = logging.getLogger(__name__)
 
@@ -47,22 +52,6 @@ class AccessApiConfig(BaseSettings):
         ...,
         description="URL pointing to the internal access API.",
         examples=["http://127.0.0.1/access"],
-    )
-
-
-class FileBoxClientConfig(BaseSettings):
-    """Config parameters for interacting with the service owning FileUploadBoxes."""
-
-    ucs_url: HttpUrl = Field(
-        ...,
-        description="URL pointing to the API of the service that owns FileUploadBoxes"
-        + " (currently the UCS).",
-        examples=["http://127.0.0.1/upload"],
-    )
-    work_order_signing_key: SecretStr = Field(
-        ...,
-        description="The private key for signing work order tokens",
-        examples=['{"crv": "P-256", "kty": "EC", "x": "...", "y": "..."}'],
     )
 
 
@@ -252,6 +241,22 @@ class AccessClient(AccessClientPort):
             raise self.AccessAPIError("Failed to check box access.") from err
 
 
+class FileBoxClientConfig(BaseSettings):
+    """Config parameters for interacting with the service owning FileUploadBoxes."""
+
+    ucs_url: HttpUrl = Field(
+        ...,
+        description="URL pointing to the API of the service that owns FileUploadBoxes"
+        + " (currently the UCS).",
+        examples=["http://127.0.0.1/upload"],
+    )
+    work_order_signing_key: SecretStr = Field(
+        ...,
+        description="The private key for signing work order tokens",
+        examples=['{"crv": "P-256", "kty": "EC", "x": "...", "y": "..."}'],
+    )
+
+
 class FileBoxClient(FileBoxClientPort):
     """An adapter for interacting with the service that owns FileUploadBoxes.
 
@@ -437,3 +442,46 @@ class FileBoxClient(FileBoxClientPort):
                 },
             )
             raise self.OperationError("Failed to archive FileUploadBox.")
+
+
+class AccessionClientConfig(BaseSettings):
+    """Config parameters for interacting with the service that manages accession numbers."""
+
+    accession_url: HttpUrl = Field(
+        ...,
+        description="URL pointing to the API of the service that manages accession numbers.",
+        examples=["http://127.0.0.1/accessions"],
+    )
+
+
+class AccessionClient(AccessionClientPort):
+    """An adapter for interacting with the service that manages accession numbers."""
+
+    def __init__(
+        self, *, config: AccessionClientConfig, httpx_client: httpx.AsyncClient
+    ):
+        self._accession_url = config.accession_url
+        self._client = httpx_client
+
+    async def submit_accession_map(self, *, accession_map: AccessionMap) -> None:
+        """Submit a map of accession numbers to file IDs.
+
+        Raises:
+            OperationError: if there's a problem during the operation.
+        """
+        json_mapping = accession_map.model_dump(mode="json")["mapping"]
+        response = await self._client.post(
+            f"{self._accession_url}/accession-map",
+            json=json_mapping,
+            timeout=HTTPX_TIMEOUT,
+        )
+        if response.status_code != 204:
+            log.error(
+                "Failed to submit accession map for ResearchDataUploadBox ID %s.",
+                accession_map.box_id,
+                extra={
+                    "status_code": response.status_code,
+                    "response_text": response.text,
+                },
+            )
+            raise self.OperationError("Failed to submit accession map.")

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -284,15 +284,13 @@ class FileBoxClient(FileBoxClientPort):
         signed_wot = sign_work_order_token(wot, self._signing_key)
         return {"Authorization": f"Bearer {signed_wot}"}
 
-    async def create_file_upload_box(
-        self, *, storage_alias: str, user_id: UUID4
-    ) -> UUID4:
+    async def create_file_upload_box(self, *, storage_alias: str) -> UUID4:
         """Create a new FileUploadBox in owning service.
 
         Raises:
             OperationError if there's a problem with the operation.
         """
-        headers = self._auth_header(CreateFileBoxWorkOrder(user_id=user_id))
+        headers = self._auth_header(CreateFileBoxWorkOrder())
         body = {"storage_alias": storage_alias}
         response = await self._client.post(
             f"{self._ucs_url}/boxes", headers=headers, json=body, timeout=HTTPX_TIMEOUT
@@ -321,13 +319,13 @@ class FileBoxClient(FileBoxClientPort):
             log.error(msg, exc_info=True)
             raise self.OperationError(msg) from err
 
-    async def lock_file_upload_box(self, *, box_id: UUID4, user_id: UUID4) -> None:
+    async def lock_file_upload_box(self, *, box_id: UUID4) -> None:
         """Lock a FileUploadBox in the owning service.
 
         Raises:
             OperationError if there's a problem with the operation.
         """
-        wot = ChangeFileBoxWorkOrder(work_type="lock", box_id=box_id, user_id=user_id)
+        wot = ChangeFileBoxWorkOrder(work_type="lock", box_id=box_id)
         headers = self._auth_header(wot)
         body = {"lock": True}
         response = await self._client.patch(
@@ -347,13 +345,13 @@ class FileBoxClient(FileBoxClientPort):
             )
             raise self.OperationError("Failed to lock FileUploadBox.")
 
-    async def unlock_file_upload_box(self, *, box_id: UUID4, user_id: UUID4) -> None:
+    async def unlock_file_upload_box(self, *, box_id: UUID4) -> None:
         """Unlock a FileUploadBox in the owning service.
 
         Raises:
             OperationError if there's a problem with the operation.
         """
-        wot = ChangeFileBoxWorkOrder(work_type="unlock", box_id=box_id, user_id=user_id)
+        wot = ChangeFileBoxWorkOrder(work_type="unlock", box_id=box_id)
 
         headers = self._auth_header(wot)
         body = {"lock": False}
@@ -375,14 +373,14 @@ class FileBoxClient(FileBoxClientPort):
             raise self.OperationError("Failed to unlock FileUploadBox.")
 
     async def get_file_upload_list(
-        self, *, box_id: UUID4, user_id: UUID4
+        self, *, box_id: UUID4
     ) -> list[FileUploadWithAccession]:
         """Get list of file uploads in a FileUploadBox.
 
         Raises:
             OperationError if there's a problem with the operation.
         """
-        wot = ViewFileBoxWorkOrder(box_id=box_id, user_id=user_id)
+        wot = ViewFileBoxWorkOrder(box_id=box_id)
         headers = self._auth_header(wot)
         response = await self._client.get(
             f"{self._ucs_url}/boxes/{box_id}/uploads",
@@ -409,18 +407,14 @@ class FileBoxClient(FileBoxClientPort):
             log.error(msg, exc_info=True)
             raise self.OperationError(msg) from err
 
-    async def archive_file_upload_box(
-        self, *, box_id: UUID4, version: int, user_id: UUID4
-    ) -> None:
+    async def archive_file_upload_box(self, *, box_id: UUID4, version: int) -> None:
         """Archive a FileUploadBox in the owning service.
 
         Raises:
             FUBVersionError if the remote box version differs from `version`.
             OperationError if there's any other problem with the operation.
         """
-        wot = ChangeFileBoxWorkOrder(
-            work_type="archive", box_id=box_id, user_id=user_id
-        )
+        wot = ChangeFileBoxWorkOrder(work_type="archive", box_id=box_id)
         headers = self._auth_header(wot)
         body = {"version": version}
         response = await self._client.patch(

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -492,7 +492,7 @@ class AccessionClient(AccessionClientPort):
         Raises:
             OperationError: if there's a problem during the operation.
         """
-        wot = SubmitAccessionMapWorkOrder(user_id=user_id)
+        wot = SubmitAccessionMapWorkOrder(user_id=user_id, study_pid=study_pid)
         json_mapping = accession_map.model_dump(mode="json")["mapping"]
         body = {"study_pid": study_pid, "mapping": json_mapping}
         response = await self._client.post(

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -53,11 +53,11 @@ from uos.ports.outbound.http import (
 log = logging.getLogger(__name__)
 
 
-class JWTSigningConfig(BaseSettings):
+class WOTSigningConfig(BaseSettings):
     """Base config for JWT use"""
 
     work_order_signing_key: SecretStr = Field(
-        ...,
+        default=...,
         description="The private key for signing work order tokens and other JWTs",
         examples=['{"crv": "P-256", "kty": "EC", "x": "...", "y": "..."}'],
     )
@@ -67,7 +67,7 @@ class AccessApiConfig(BaseSettings):
     """Config parameters for managing upload access grants."""
 
     access_url: HttpUrl = Field(
-        ...,
+        default=...,
         description="URL pointing to the internal access API.",
         examples=["http://127.0.0.1/access"],
     )
@@ -259,11 +259,11 @@ class AccessClient(AccessClientPort):
             raise self.AccessAPIError("Failed to check box access.") from err
 
 
-class FileBoxClientConfig(JWTSigningConfig):
+class FileBoxClientConfig(WOTSigningConfig):
     """Config parameters for interacting with the service owning FileUploadBoxes."""
 
     ucs_url: HttpUrl = Field(
-        ...,
+        default=...,
         description="URL pointing to the API of the service that owns FileUploadBoxes"
         + " (currently the UCS).",
         examples=["http://127.0.0.1/upload"],
@@ -463,11 +463,11 @@ class FileBoxClient(FileBoxClientPort):
             raise self.OperationError("Failed to archive FileUploadBox.")
 
 
-class AccessionClientConfig(JWTSigningConfig):
+class AccessionClientConfig(WOTSigningConfig):
     """Config parameters for interacting with the service that manages accession numbers."""
 
     accession_url: HttpUrl = Field(
-        ...,
+        default=...,
         description=(
             "URL pointing to the API of the service that manages accession"
             + " numbers (currently the study registry service)."

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -496,7 +496,7 @@ class AccessionClient(AccessionClientPort):
         json_mapping = accession_map.model_dump(mode="json")["mapping"]
         body = {"study_pid": study_pid, "mapping": json_mapping}
         response = await self._client.post(
-            f"{self._accession_url}/file-ids",
+            f"{self._accession_url}/file-ids/{study_pid}",
             headers=self._auth_header(wot),
             json=body,
             timeout=HTTPX_TIMEOUT,

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -20,12 +20,20 @@ from typing import Any
 from uuid import UUID
 
 import httpx
+from ghga_service_commons.utils.jwt_helpers import sign_and_serialize_token
 from ghga_service_commons.utils.utc_dates import UTCDatetime
 from jwcrypto import jwk
+from jwcrypto.jwk import JWK
 from pydantic import UUID4, Field, HttpUrl, SecretStr
 from pydantic_settings import BaseSettings
 
-from uos.constants import HTTPX_TIMEOUT
+from uos.constants import (
+    AUTH_TOKEN_VALID_SECONDS,
+    HTTPX_TIMEOUT,
+    JWT_AUD,
+    JWT_ISS,
+    JWT_SUB,
+)
 from uos.core.models import (
     AccessionMap,
     BaseWorkOrderToken,
@@ -43,6 +51,16 @@ from uos.ports.outbound.http import (
 )
 
 log = logging.getLogger(__name__)
+
+
+class JWTSigningConfig(BaseSettings):
+    """Base config for JWT use"""
+
+    jwt_signing_key: SecretStr = Field(
+        ...,
+        description="The private key for signing work order tokens and other JWTs",
+        examples=['{"crv": "P-256", "kty": "EC", "x": "...", "y": "..."}'],
+    )
 
 
 class AccessApiConfig(BaseSettings):
@@ -241,7 +259,7 @@ class AccessClient(AccessClientPort):
             raise self.AccessAPIError("Failed to check box access.") from err
 
 
-class FileBoxClientConfig(BaseSettings):
+class FileBoxClientConfig(JWTSigningConfig):
     """Config parameters for interacting with the service owning FileUploadBoxes."""
 
     ucs_url: HttpUrl = Field(
@@ -249,11 +267,6 @@ class FileBoxClientConfig(BaseSettings):
         description="URL pointing to the API of the service that owns FileUploadBoxes"
         + " (currently the UCS).",
         examples=["http://127.0.0.1/upload"],
-    )
-    work_order_signing_key: SecretStr = Field(
-        ...,
-        description="The private key for signing work order tokens",
-        examples=['{"crv": "P-256", "kty": "EC", "x": "...", "y": "..."}'],
     )
 
 
@@ -266,9 +279,7 @@ class FileBoxClient(FileBoxClientPort):
     def __init__(self, *, config: FileBoxClientConfig, httpx_client: httpx.AsyncClient):
         self._ucs_url = config.ucs_url
         self._client = httpx_client
-        self._signing_key = jwk.JWK.from_json(
-            config.work_order_signing_key.get_secret_value()
-        )
+        self._signing_key = jwk.JWK.from_json(config.jwt_signing_key.get_secret_value())
         if not self._signing_key.has_private:
             key_error = KeyError("No private work order signing key found.")
             log.error(key_error)
@@ -444,7 +455,7 @@ class FileBoxClient(FileBoxClientPort):
             raise self.OperationError("Failed to archive FileUploadBox.")
 
 
-class AccessionClientConfig(BaseSettings):
+class AccessionClientConfig(JWTSigningConfig):
     """Config parameters for interacting with the service that manages accession numbers."""
 
     accession_url: HttpUrl = Field(
@@ -460,8 +471,23 @@ class AccessionClient(AccessionClientPort):
     def __init__(
         self, *, config: AccessionClientConfig, httpx_client: httpx.AsyncClient
     ):
-        self._accession_url = config.accession_url
         self._client = httpx_client
+        self._accession_url = config.accession_url
+        self._signing_key = JWK.from_json(config.jwt_signing_key.get_secret_value())
+        if not self._signing_key.has_private:
+            value_error = ValueError("No private token-signing key found.")
+            log.error(value_error)
+            raise value_error
+
+    def _make_jwt(self) -> str:
+        claims: dict[str, str] = {"iss": JWT_ISS, "aud": JWT_AUD, "sub": JWT_SUB}
+        return sign_and_serialize_token(
+            claims=claims, key=self._signing_key, valid_seconds=AUTH_TOKEN_VALID_SECONDS
+        )
+
+    def _auth_headers(self) -> dict[str, str]:
+        """Create an authorization header with a bearer token containing a fresh JWT"""
+        return {"Authorization": f"Bearer {self._make_jwt()}"}
 
     async def submit_accession_map(self, *, accession_map: AccessionMap) -> None:
         """Submit a map of accession numbers to file IDs.
@@ -471,7 +497,8 @@ class AccessionClient(AccessionClientPort):
         """
         json_mapping = accession_map.model_dump(mode="json")["mapping"]
         response = await self._client.post(
-            f"{self._accession_url}/accession-map",
+            f"{self._accession_url}/accession-maps",
+            headers=self._auth_headers(),
             json=json_mapping,
             timeout=HTTPX_TIMEOUT,
         )

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -27,6 +27,7 @@ from pydantic_settings import BaseSettings
 
 from uos.constants import HTTPX_TIMEOUT
 from uos.core.models import (
+    PID,
     AccessionMap,
     BaseWorkOrderToken,
     ChangeFileBoxWorkOrder,
@@ -483,7 +484,7 @@ class AccessionClient(AccessionClientPort):
         return {"Authorization": f"Bearer {signed_wot}"}
 
     async def submit_accession_map(
-        self, *, accession_map: AccessionMap, study_pid: str, user_id: UUID4
+        self, *, accession_map: AccessionMap, study_pid: PID, user_id: UUID4
     ) -> None:
         """Submit a map of accession numbers to file IDs.
 

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -292,13 +292,15 @@ class FileBoxClient(FileBoxClientPort):
         headers = {"Authorization": f"Bearer {signed_wot}"}
         return headers
 
-    async def create_file_upload_box(self, *, storage_alias: str) -> UUID4:
+    async def create_file_upload_box(
+        self, *, storage_alias: str, user_id: UUID4
+    ) -> UUID4:
         """Create a new FileUploadBox in owning service.
 
         Raises:
             OperationError if there's a problem with the operation.
         """
-        headers = self._auth_header(CreateFileBoxWorkOrder())
+        headers = self._auth_header(CreateFileBoxWorkOrder(user_id=user_id))
         body = {"storage_alias": storage_alias}
         response = await self._client.post(
             f"{self._ucs_url}/boxes", headers=headers, json=body, timeout=HTTPX_TIMEOUT
@@ -327,13 +329,13 @@ class FileBoxClient(FileBoxClientPort):
             log.error(msg, exc_info=True)
             raise self.OperationError(msg) from err
 
-    async def lock_file_upload_box(self, *, box_id: UUID4) -> None:
+    async def lock_file_upload_box(self, *, box_id: UUID4, user_id: UUID4) -> None:
         """Lock a FileUploadBox in the owning service.
 
         Raises:
             OperationError if there's a problem with the operation.
         """
-        wot = ChangeFileBoxWorkOrder(work_type="lock", box_id=box_id)
+        wot = ChangeFileBoxWorkOrder(work_type="lock", box_id=box_id, user_id=user_id)
         headers = self._auth_header(wot)
         body = {"lock": True}
         response = await self._client.patch(
@@ -353,13 +355,13 @@ class FileBoxClient(FileBoxClientPort):
             )
             raise self.OperationError("Failed to lock FileUploadBox.")
 
-    async def unlock_file_upload_box(self, *, box_id: UUID4) -> None:
+    async def unlock_file_upload_box(self, *, box_id: UUID4, user_id: UUID4) -> None:
         """Unlock a FileUploadBox in the owning service.
 
         Raises:
             OperationError if there's a problem with the operation.
         """
-        wot = ChangeFileBoxWorkOrder(work_type="unlock", box_id=box_id)
+        wot = ChangeFileBoxWorkOrder(work_type="unlock", box_id=box_id, user_id=user_id)
 
         headers = self._auth_header(wot)
         body = {"lock": False}
@@ -381,14 +383,14 @@ class FileBoxClient(FileBoxClientPort):
             raise self.OperationError("Failed to unlock FileUploadBox.")
 
     async def get_file_upload_list(
-        self, *, box_id: UUID4
+        self, *, box_id: UUID4, user_id: UUID4
     ) -> list[FileUploadWithAccession]:
         """Get list of file uploads in a FileUploadBox.
 
         Raises:
             OperationError if there's a problem with the operation.
         """
-        wot = ViewFileBoxWorkOrder(box_id=box_id)
+        wot = ViewFileBoxWorkOrder(box_id=box_id, user_id=user_id)
         headers = self._auth_header(wot)
         response = await self._client.get(
             f"{self._ucs_url}/boxes/{box_id}/uploads",
@@ -415,14 +417,18 @@ class FileBoxClient(FileBoxClientPort):
             log.error(msg, exc_info=True)
             raise self.OperationError(msg) from err
 
-    async def archive_file_upload_box(self, *, box_id: UUID4, version: int) -> None:
+    async def archive_file_upload_box(
+        self, *, box_id: UUID4, version: int, user_id: UUID4
+    ) -> None:
         """Archive a FileUploadBox in the owning service.
 
         Raises:
             FUBVersionError if the remote box version differs from `version`.
             OperationError if there's any other problem with the operation.
         """
-        wot = ChangeFileBoxWorkOrder(work_type="archive", box_id=box_id)
+        wot = ChangeFileBoxWorkOrder(
+            work_type="archive", box_id=box_id, user_id=user_id
+        )
         headers = self._auth_header(wot)
         body = {"version": version}
         response = await self._client.patch(

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -507,6 +507,7 @@ class AccessionClient(AccessionClientPort):
                 "Failed to submit accession map for ResearchDataUploadBox ID %s.",
                 accession_map.box_id,
                 extra={
+                    "research_data_upload_box_id": accession_map.box_id,
                     "status_code": response.status_code,
                     "response_text": response.text,
                 },

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -56,7 +56,7 @@ log = logging.getLogger(__name__)
 class JWTSigningConfig(BaseSettings):
     """Base config for JWT use"""
 
-    jwt_signing_key: SecretStr = Field(
+    work_order_signing_key: SecretStr = Field(
         ...,
         description="The private key for signing work order tokens and other JWTs",
         examples=['{"crv": "P-256", "kty": "EC", "x": "...", "y": "..."}'],
@@ -279,7 +279,9 @@ class FileBoxClient(FileBoxClientPort):
     def __init__(self, *, config: FileBoxClientConfig, httpx_client: httpx.AsyncClient):
         self._ucs_url = config.ucs_url
         self._client = httpx_client
-        self._signing_key = jwk.JWK.from_json(config.jwt_signing_key.get_secret_value())
+        self._signing_key = jwk.JWK.from_json(
+            config.work_order_signing_key.get_secret_value()
+        )
         if not self._signing_key.has_private:
             key_error = KeyError("No private work order signing key found.")
             log.error(key_error)
@@ -460,7 +462,10 @@ class AccessionClientConfig(JWTSigningConfig):
 
     accession_url: HttpUrl = Field(
         ...,
-        description="URL pointing to the API of the service that manages accession numbers.",
+        description=(
+            "URL pointing to the API of the service that manages accession"
+            + " numbers (currently the study registry service)."
+        ),
         examples=["http://127.0.0.1/accessions"],
     )
 
@@ -473,7 +478,9 @@ class AccessionClient(AccessionClientPort):
     ):
         self._client = httpx_client
         self._accession_url = config.accession_url
-        self._signing_key = JWK.from_json(config.jwt_signing_key.get_secret_value())
+        self._signing_key = JWK.from_json(
+            config.work_order_signing_key.get_secret_value()
+        )
         if not self._signing_key.has_private:
             value_error = ValueError("No private token-signing key found.")
             log.error(value_error)
@@ -497,7 +504,7 @@ class AccessionClient(AccessionClientPort):
         """
         json_mapping = accession_map.model_dump(mode="json")["mapping"]
         response = await self._client.post(
-            f"{self._accession_url}/accession-maps",
+            f"{self._accession_url}/file-ids",
             headers=self._auth_headers(),
             json=json_mapping,
             timeout=HTTPX_TIMEOUT,

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -20,26 +20,19 @@ from typing import Any
 from uuid import UUID
 
 import httpx
-from ghga_service_commons.utils.jwt_helpers import sign_and_serialize_token
 from ghga_service_commons.utils.utc_dates import UTCDatetime
 from jwcrypto import jwk
-from jwcrypto.jwk import JWK
 from pydantic import UUID4, Field, HttpUrl, SecretStr
 from pydantic_settings import BaseSettings
 
-from uos.constants import (
-    AUTH_TOKEN_VALID_SECONDS,
-    HTTPX_TIMEOUT,
-    JWT_AUD,
-    JWT_ISS,
-    JWT_SUB,
-)
+from uos.constants import HTTPX_TIMEOUT
 from uos.core.models import (
     AccessionMap,
     BaseWorkOrderToken,
     ChangeFileBoxWorkOrder,
     CreateFileBoxWorkOrder,
     FileUploadWithAccession,
+    SubmitAccessionMapWorkOrder,
     UploadGrant,
     ViewFileBoxWorkOrder,
 )
@@ -289,8 +282,7 @@ class FileBoxClient(FileBoxClientPort):
 
     def _auth_header(self, wot: BaseWorkOrderToken) -> dict[str, str]:
         signed_wot = sign_work_order_token(wot, self._signing_key)
-        headers = {"Authorization": f"Bearer {signed_wot}"}
-        return headers
+        return {"Authorization": f"Bearer {signed_wot}"}
 
     async def create_file_upload_box(
         self, *, storage_alias: str, user_id: UUID4
@@ -484,7 +476,7 @@ class AccessionClient(AccessionClientPort):
     ):
         self._client = httpx_client
         self._accession_url = config.accession_url
-        self._signing_key = JWK.from_json(
+        self._signing_key = jwk.JWK.from_json(
             config.work_order_signing_key.get_secret_value()
         )
         if not self._signing_key.has_private:
@@ -492,27 +484,27 @@ class AccessionClient(AccessionClientPort):
             log.error(value_error)
             raise value_error
 
-    def _make_jwt(self) -> str:
-        claims: dict[str, str] = {"iss": JWT_ISS, "aud": JWT_AUD, "sub": JWT_SUB}
-        return sign_and_serialize_token(
-            claims=claims, key=self._signing_key, valid_seconds=AUTH_TOKEN_VALID_SECONDS
-        )
+    def _auth_header(self, wot: BaseWorkOrderToken) -> dict[str, str]:
+        signed_wot = sign_work_order_token(wot, self._signing_key)
+        return {"Authorization": f"Bearer {signed_wot}"}
 
-    def _auth_headers(self) -> dict[str, str]:
-        """Create an authorization header with a bearer token containing a fresh JWT"""
-        return {"Authorization": f"Bearer {self._make_jwt()}"}
-
-    async def submit_accession_map(self, *, accession_map: AccessionMap) -> None:
+    async def submit_accession_map(
+        self, *, accession_map: AccessionMap, study_pid: str, user_id: UUID4
+    ) -> None:
         """Submit a map of accession numbers to file IDs.
+
+        The study_pid is a passthrough value required by SRS but not interpreted by UOS.
 
         Raises:
             OperationError: if there's a problem during the operation.
         """
+        wot = SubmitAccessionMapWorkOrder(user_id=user_id)
         json_mapping = accession_map.model_dump(mode="json")["mapping"]
+        body = {"study_pid": study_pid, "mapping": json_mapping}
         response = await self._client.post(
             f"{self._accession_url}/file-ids",
-            headers=self._auth_headers(),
-            json=json_mapping,
+            headers=self._auth_header(wot),
+            json=body,
             timeout=HTTPX_TIMEOUT,
         )
         if response.status_code != 204:

--- a/src/uos/cli.py
+++ b/src/uos/cli.py
@@ -16,10 +16,11 @@
 """Entrypoint of the package"""
 
 import asyncio
+from typing import Annotated
 
 import typer
 
-from uos.main import consume_events, run_rest_app
+from uos.main import consume_events, publish_events, run_rest_app
 
 cli = typer.Typer()
 
@@ -34,3 +35,13 @@ def sync_run_api():
 def sync_consume_events(run_forever: bool = True):
     """Run an event consumer listening to the specified topic."""
     asyncio.run(consume_events(run_forever=run_forever))
+
+
+@cli.command(name="publish-events")
+def sync_run_publish_events(
+    all: Annotated[
+        bool, typer.Option(help="Set to (re)publish all events regardless of status")
+    ] = False,
+):
+    """Publish pending events."""
+    asyncio.run(publish_events(all=all))

--- a/src/uos/config.py
+++ b/src/uos/config.py
@@ -25,7 +25,11 @@ from hexkit.providers.mongokafka import MongoKafkaConfig
 from uos.adapters.inbound.event_sub import OutboxSubConfig
 from uos.adapters.outbound.dao import OutboxPubConfig
 from uos.adapters.outbound.event_pub import EventPubConfig
-from uos.adapters.outbound.http import AccessApiConfig, FileBoxClientConfig
+from uos.adapters.outbound.http import (
+    AccessApiConfig,
+    AccessionClientConfig,
+    FileBoxClientConfig,
+)
 from uos.constants import SERVICE_NAME
 
 __all__ = ["Config"]
@@ -40,6 +44,7 @@ class Config(
     MongoKafkaConfig,
     AccessApiConfig,
     FileBoxClientConfig,
+    AccessionClientConfig,
     EventPubConfig,
     OutboxSubConfig,
     OutboxPubConfig,

--- a/src/uos/constants.py
+++ b/src/uos/constants.py
@@ -29,3 +29,7 @@ VALID_STATE_TRANSITIONS = [
     ("locked", "open"),
     ("locked", "archived"),
 ]
+AUTH_TOKEN_VALID_SECONDS = 60
+JWT_ISS = "GHGA"
+JWT_AUD = "GHGA"
+JWT_SUB = "AccessionMap"

--- a/src/uos/constants.py
+++ b/src/uos/constants.py
@@ -29,7 +29,3 @@ VALID_STATE_TRANSITIONS = [
     ("locked", "open"),
     ("locked", "archived"),
 ]
-AUTH_TOKEN_VALID_SECONDS = 60
-JWT_ISS = "GHGA"
-JWT_AUD = "GHGA"
-JWT_SUB = "AccessionMap"

--- a/src/uos/core/models.py
+++ b/src/uos/core/models.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 from ghga_service_commons.utils.utc_dates import UTCDatetime
 from pydantic import (
     UUID4,
+    AfterValidator,
     BaseModel,
     ConfigDict,
     EmailStr,
@@ -31,6 +32,17 @@ from pydantic import (
 )
 
 UploadBoxState = Literal["open", "locked", "archived"]
+
+
+def _ascii_only(v: str) -> str:
+    if not v.isascii():
+        raise ValueError("must contain only ASCII characters")
+    return v
+
+
+PID = Annotated[
+    str, StringConstraints(min_length=1, max_length=256), AfterValidator(_ascii_only)
+]
 
 
 class ResearchDataUploadBox(BaseModel):
@@ -105,7 +117,7 @@ class SubmitAccessionMapWorkOrder(BaseWorkOrderToken):
 
     work_type: Literal["map"] = "map"
     user_id: UUID4
-    study_pid: str
+    study_pid: PID
 
 
 # API Request/Response models
@@ -212,7 +224,7 @@ class AccessionMapRequest(BaseModel):
     mapping: dict[Accession, UUID4] = Field(
         default=..., description="Map of accessions to file IDs"
     )
-    study_pid: str = Field(
+    study_pid: PID = Field(
         default=...,
         description="Identifier of the study to which the file accessions belong.",
     )

--- a/src/uos/core/models.py
+++ b/src/uos/core/models.py
@@ -77,6 +77,7 @@ class BaseWorkOrderToken(BaseModel):
     """Base model for work order tokens."""
 
     work_type: str
+    user_id: UUID4
     model_config = ConfigDict(frozen=True)
 
 

--- a/src/uos/core/models.py
+++ b/src/uos/core/models.py
@@ -101,6 +101,12 @@ class ViewFileBoxWorkOrder(BaseWorkOrderToken):
     box_id: UUID4 = Field(..., description="ID of the box to view")
 
 
+class SubmitAccessionMapWorkOrder(BaseWorkOrderToken):
+    """Work order token for submitting an accession map."""
+
+    work_type: Literal["map"] = "map"
+
+
 # API Request/Response models
 class CreateUploadBoxRequest(BaseModel):
     """Request model for creating a new research data upload box."""
@@ -200,10 +206,14 @@ class AccessionMapRequest(BaseModel):
     """The request body schema for submitting accession maps"""
 
     version: int = Field(
-        ..., description="A counter indicating research data upload box version"
+        default=..., description="A counter indicating research data upload box version"
     )
     mapping: dict[Accession, UUID4] = Field(
         default=..., description="Map of accessions to file IDs"
+    )
+    study_pid: str = Field(
+        default=...,
+        description="Identifier of the study to which the file accessions belong.",
     )
 
 

--- a/src/uos/core/models.py
+++ b/src/uos/core/models.py
@@ -77,7 +77,6 @@ class BaseWorkOrderToken(BaseModel):
     """Base model for work order tokens."""
 
     work_type: str
-    user_id: UUID4
     model_config = ConfigDict(frozen=True)
 
 
@@ -105,6 +104,7 @@ class SubmitAccessionMapWorkOrder(BaseWorkOrderToken):
     """Work order token for submitting an accession map."""
 
     work_type: Literal["map"] = "map"
+    user_id: UUID4
 
 
 # API Request/Response models

--- a/src/uos/core/models.py
+++ b/src/uos/core/models.py
@@ -105,6 +105,7 @@ class SubmitAccessionMapWorkOrder(BaseWorkOrderToken):
 
     work_type: Literal["map"] = "map"
     user_id: UUID4
+    study_pid: str
 
 
 # API Request/Response models

--- a/src/uos/core/orchestrator.py
+++ b/src/uos/core/orchestrator.py
@@ -98,7 +98,7 @@ class UploadOrchestrator(UploadOrchestratorPort):
         """
         # Create FileUploadBox in external service
         file_upload_box_id = await self._file_upload_box_client.create_file_upload_box(
-            storage_alias=storage_alias, user_id=data_steward_id
+            storage_alias=storage_alias
         )
 
         # Create ResearchDataUploadBox
@@ -197,9 +197,7 @@ class UploadOrchestrator(UploadOrchestratorPort):
 
         # Take the appropriate action for the state change and roll back if it fails
         try:
-            await self._handle_state_change(
-                old_box=box, updated_box=updated_box, user_id=user_id
-            )
+            await self._handle_state_change(old_box=box, updated_box=updated_box)
         except Exception:
             log.warning(
                 "Failed to update FUB %s, rolling back changes for RDUB %s",
@@ -229,7 +227,6 @@ class UploadOrchestrator(UploadOrchestratorPort):
         *,
         old_box: ResearchDataUploadBox,
         updated_box: ResearchDataUploadBox,
-        user_id: UUID4,
     ) -> None:
         """Handle state change for a Research Data Upload Box and the corresponding
         FileUploadBox.
@@ -238,23 +235,18 @@ class UploadOrchestrator(UploadOrchestratorPort):
         fub_id = updated_box.file_upload_box_id
         match (old_box.state, updated_box.state):
             case ("open", "locked"):  # lock the box
-                await self._file_upload_box_client.lock_file_upload_box(
-                    box_id=fub_id, user_id=user_id
-                )
+                await self._file_upload_box_client.lock_file_upload_box(box_id=fub_id)
             case ("locked", "open"):  # unlock the box
-                await self._file_upload_box_client.unlock_file_upload_box(
-                    box_id=fub_id, user_id=user_id
-                )
+                await self._file_upload_box_client.unlock_file_upload_box(box_id=fub_id)
             case ("locked", "archived"):  # archive the box
                 # Check prerequisites using old version number for logging purposes
-                await self._check_archival_prerequisites(box=old_box, user_id=user_id)
+                await self._check_archival_prerequisites(box=old_box)
 
                 # Use old box data because `updated_box` has already been, well, updated
                 try:
                     await self._file_upload_box_client.archive_file_upload_box(
                         box_id=fub_id,
                         version=old_box.file_upload_box_version,
-                        user_id=user_id,
                     )
                 except FileBoxClientPort.FUBVersionError as version_err:
                     log.error(
@@ -275,7 +267,7 @@ class UploadOrchestrator(UploadOrchestratorPort):
                 raise NotImplementedError()
 
     async def _check_archival_prerequisites(
-        self, *, box: ResearchDataUploadBox, user_id: UUID4
+        self, *, box: ResearchDataUploadBox
     ) -> None:
         """Archive a research data upload box.
 
@@ -300,7 +292,7 @@ class UploadOrchestrator(UploadOrchestratorPort):
 
         # Get files list from File Box API - this always gets the latest data
         files = await self._file_upload_box_client.get_file_upload_list(
-            box_id=box.file_upload_box_id, user_id=user_id
+            box_id=box.file_upload_box_id
         )
 
         # Make sure all files have an accession number
@@ -449,9 +441,8 @@ class UploadOrchestrator(UploadOrchestratorPort):
         )
 
         # Get file list from file box service
-        user_id = UUID(auth_context.id)
         file_uploads = await self._file_upload_box_client.get_file_upload_list(
-            box_id=upload_box.file_upload_box_id, user_id=user_id
+            box_id=upload_box.file_upload_box_id
         )
 
         # Get accessions from database
@@ -696,7 +687,7 @@ class UploadOrchestrator(UploadOrchestratorPort):
 
         # Get files list from File Box API
         files = await self._file_upload_box_client.get_file_upload_list(
-            box_id=box.file_upload_box_id, user_id=user_id
+            box_id=box.file_upload_box_id
         )
 
         # Make sure all specified file IDs are active uploads in the box

--- a/src/uos/core/orchestrator.py
+++ b/src/uos/core/orchestrator.py
@@ -98,7 +98,7 @@ class UploadOrchestrator(UploadOrchestratorPort):
         """
         # Create FileUploadBox in external service
         file_upload_box_id = await self._file_upload_box_client.create_file_upload_box(
-            storage_alias=storage_alias
+            storage_alias=storage_alias, user_id=data_steward_id
         )
 
         # Create ResearchDataUploadBox
@@ -197,7 +197,9 @@ class UploadOrchestrator(UploadOrchestratorPort):
 
         # Take the appropriate action for the state change and roll back if it fails
         try:
-            await self._handle_state_change(old_box=box, updated_box=updated_box)
+            await self._handle_state_change(
+                old_box=box, updated_box=updated_box, user_id=user_id
+            )
         except Exception:
             log.warning(
                 "Failed to update FUB %s, rolling back changes for RDUB %s",
@@ -223,7 +225,11 @@ class UploadOrchestrator(UploadOrchestratorPort):
             raise self.StateChangeError(old_state=old_state, new_state=new_state)
 
     async def _handle_state_change(
-        self, *, old_box: ResearchDataUploadBox, updated_box: ResearchDataUploadBox
+        self,
+        *,
+        old_box: ResearchDataUploadBox,
+        updated_box: ResearchDataUploadBox,
+        user_id: UUID4,
     ) -> None:
         """Handle state change for a Research Data Upload Box and the corresponding
         FileUploadBox.
@@ -232,17 +238,23 @@ class UploadOrchestrator(UploadOrchestratorPort):
         fub_id = updated_box.file_upload_box_id
         match (old_box.state, updated_box.state):
             case ("open", "locked"):  # lock the box
-                await self._file_upload_box_client.lock_file_upload_box(box_id=fub_id)
+                await self._file_upload_box_client.lock_file_upload_box(
+                    box_id=fub_id, user_id=user_id
+                )
             case ("locked", "open"):  # unlock the box
-                await self._file_upload_box_client.unlock_file_upload_box(box_id=fub_id)
+                await self._file_upload_box_client.unlock_file_upload_box(
+                    box_id=fub_id, user_id=user_id
+                )
             case ("locked", "archived"):  # archive the box
                 # Check prerequisites using old version number for logging purposes
-                await self._check_archival_prerequisites(box=old_box)
+                await self._check_archival_prerequisites(box=old_box, user_id=user_id)
 
                 # Use old box data because `updated_box` has already been, well, updated
                 try:
                     await self._file_upload_box_client.archive_file_upload_box(
-                        box_id=fub_id, version=old_box.file_upload_box_version
+                        box_id=fub_id,
+                        version=old_box.file_upload_box_version,
+                        user_id=user_id,
                     )
                 except FileBoxClientPort.FUBVersionError as version_err:
                     log.error(
@@ -263,7 +275,7 @@ class UploadOrchestrator(UploadOrchestratorPort):
                 raise NotImplementedError()
 
     async def _check_archival_prerequisites(
-        self, *, box: ResearchDataUploadBox
+        self, *, box: ResearchDataUploadBox, user_id: UUID4
     ) -> None:
         """Archive a research data upload box.
 
@@ -288,7 +300,7 @@ class UploadOrchestrator(UploadOrchestratorPort):
 
         # Get files list from File Box API - this always gets the latest data
         files = await self._file_upload_box_client.get_file_upload_list(
-            box_id=box.file_upload_box_id
+            box_id=box.file_upload_box_id, user_id=user_id
         )
 
         # Make sure all files have an accession number
@@ -437,8 +449,9 @@ class UploadOrchestrator(UploadOrchestratorPort):
         )
 
         # Get file list from file box service
+        user_id = UUID(auth_context.id)
         file_uploads = await self._file_upload_box_client.get_file_upload_list(
-            box_id=upload_box.file_upload_box_id,
+            box_id=upload_box.file_upload_box_id, user_id=user_id
         )
 
         # Get accessions from database
@@ -601,7 +614,7 @@ class UploadOrchestrator(UploadOrchestratorPort):
         return BoxRetrievalResults(count=count, boxes=boxes)
 
     async def update_accession_map(
-        self, *, box_id: UUID4, request: AccessionMapRequest
+        self, *, box_id: UUID4, request: AccessionMapRequest, user_id: UUID4
     ) -> None:
         """Update the file accession map for a given box and publish an outbox event.
         This results in a version increment for the ResearchDataUploadBox.
@@ -679,7 +692,7 @@ class UploadOrchestrator(UploadOrchestratorPort):
 
         # Get files list from File Box API
         files = await self._file_upload_box_client.get_file_upload_list(
-            box_id=box.file_upload_box_id
+            box_id=box.file_upload_box_id, user_id=user_id
         )
 
         # Make sure all specified file IDs are active uploads in the box

--- a/src/uos/core/orchestrator.py
+++ b/src/uos/core/orchestrator.py
@@ -39,7 +39,11 @@ from uos.core.models import (
 from uos.ports.inbound.orchestrator import UploadOrchestratorPort
 from uos.ports.outbound.audit import AuditRepositoryPort
 from uos.ports.outbound.dao import AccessionMapDao, BoxDao
-from uos.ports.outbound.http import AccessClientPort, FileBoxClientPort
+from uos.ports.outbound.http import (
+    AccessClientPort,
+    AccessionClientPort,
+    FileBoxClientPort,
+)
 
 log = logging.getLogger(__name__)
 
@@ -54,7 +58,7 @@ def is_data_steward(auth_context: AuthContext) -> bool:
 class UploadOrchestrator(UploadOrchestratorPort):
     """A class for orchestrating upload operations."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         box_dao: BoxDao,
@@ -62,12 +66,14 @@ class UploadOrchestrator(UploadOrchestratorPort):
         audit_repository: AuditRepositoryPort,
         file_upload_box_client: FileBoxClientPort,
         access_client: AccessClientPort,
+        accession_client: AccessionClientPort,
     ):
         self._box_dao = box_dao
         self._accession_map_dao = accession_map_dao
         self._audit_repository = audit_repository
         self._file_upload_box_client = file_upload_box_client
         self._access_client = access_client
+        self._accession_client = accession_client
 
     async def create_research_data_upload_box(
         self,
@@ -613,12 +619,13 @@ class UploadOrchestrator(UploadOrchestratorPort):
         - each file ID in the mapping exists in the retrieved list of files
         - all file IDs in the box are included in the mapping
 
-        Finally, store the mapping in the DB and publish an outbox event containing
-        the mapping field content.
+        Finally, submit the accession map to the Accession API and store it in the DB.
 
         Raises:
             BoxNotFoundError: If the box doesn't exist
             VersionError: If the requested ResearchDataUploadBox version is outdated
+            OperationError: If there's a problem submitting the accession map to the
+                Accession API
             AccessionMapError: If
             - the box is already archived, or
             - the accession map includes a file ID that doesn't exist in the box, or
@@ -710,9 +717,14 @@ class UploadOrchestrator(UploadOrchestratorPort):
                 f" {', '.join(map(str, unmapped_ids))}."
             )
 
+        # Submit the data to the Accession API
+        accession_mapping = AccessionMap(box_id=box_id, mapping=request.mapping)
+        await self._accession_client.submit_accession_map(
+            accession_map=accession_mapping
+        )
+
         try:
-            # Store the data and publish an outbox event
-            accession_mapping = AccessionMap(box_id=box_id, mapping=request.mapping)
+            # Store the data
             await self._accession_map_dao.upsert(accession_mapping)
             log.info("Accession map upserted for RDUB %s", box_id)
         except DaoError as err:

--- a/src/uos/core/orchestrator.py
+++ b/src/uos/core/orchestrator.py
@@ -614,7 +614,11 @@ class UploadOrchestrator(UploadOrchestratorPort):
         return BoxRetrievalResults(count=count, boxes=boxes)
 
     async def update_accession_map(
-        self, *, box_id: UUID4, request: AccessionMapRequest, user_id: UUID4
+        self,
+        *,
+        box_id: UUID4,
+        request: AccessionMapRequest,
+        user_id: UUID4,
     ) -> None:
         """Update the file accession map for a given box and publish an outbox event.
         This results in a version increment for the ResearchDataUploadBox.
@@ -733,7 +737,9 @@ class UploadOrchestrator(UploadOrchestratorPort):
         # Submit the data to the Accession API
         accession_mapping = AccessionMap(box_id=box_id, mapping=request.mapping)
         await self._accession_client.submit_accession_map(
-            accession_map=accession_mapping
+            accession_map=accession_mapping,
+            study_pid=request.study_pid,
+            user_id=user_id,
         )
 
         try:

--- a/src/uos/inject.py
+++ b/src/uos/inject.py
@@ -66,7 +66,6 @@ async def get_persistent_publisher(
         PersistentKafkaPublisher.construct(
             config=config,
             dao_factory=_dao_factory,
-            compacted_topics={config.accession_map_topic},
             collection_name="uosPersistedEvents",
         ) as persistent_publisher,
     ):

--- a/src/uos/inject.py
+++ b/src/uos/inject.py
@@ -38,7 +38,7 @@ from uos.adapters.inbound.fastapi_.configure import get_configured_app
 from uos.adapters.outbound.audit import AuditRepository
 from uos.adapters.outbound.dao import get_accession_map_dao, get_box_dao
 from uos.adapters.outbound.event_pub import EventPubTranslator
-from uos.adapters.outbound.http import AccessClient, FileBoxClient
+from uos.adapters.outbound.http import AccessClient, AccessionClient, FileBoxClient
 from uos.config import Config
 from uos.constants import SERVICE_NAME
 from uos.core.orchestrator import UploadOrchestrator
@@ -95,11 +95,10 @@ async def prepare_core(*, config: Config) -> AsyncGenerator[UploadOrchestratorPo
         box_dao = await get_box_dao(
             config=config, dao_publisher_factory=dao_publisher_factory
         )
-        accession_map_dao = await get_accession_map_dao(
-            config=config, dao_publisher_factory=dao_publisher_factory
-        )
+        accession_map_dao = await get_accession_map_dao(dao_factory=dao_factory)
         access_client = AccessClient(config=config, httpx_client=httpx_client)
         file_upload_box_client = FileBoxClient(config=config, httpx_client=httpx_client)
+        accession_client = AccessionClient(config=config, httpx_client=httpx_client)
 
         yield UploadOrchestrator(
             box_dao=box_dao,
@@ -107,6 +106,7 @@ async def prepare_core(*, config: Config) -> AsyncGenerator[UploadOrchestratorPo
             audit_repository=audit_repository,
             access_client=access_client,
             file_upload_box_client=file_upload_box_client,
+            accession_client=accession_client,
         )
 
 

--- a/src/uos/inject.py
+++ b/src/uos/inject.py
@@ -45,6 +45,7 @@ from uos.core.orchestrator import UploadOrchestrator
 from uos.ports.inbound.orchestrator import UploadOrchestratorPort
 
 __all__ = [
+    "get_persistent_publisher",
     "prepare_core",
     "prepare_event_subscriber",
     "prepare_rest_app",

--- a/src/uos/main.py
+++ b/src/uos/main.py
@@ -22,9 +22,15 @@ Additional endpoints might be structured in dedicated modules
 
 from ghga_service_commons.api import run_server
 from hexkit.log import configure_logging
+from hexkit.providers.mongokafka import MongoKafkaDaoPublisherFactory
 
+from uos.adapters.outbound.dao import get_box_dao
 from uos.config import Config
-from uos.inject import prepare_event_subscriber, prepare_rest_app
+from uos.inject import (
+    get_persistent_publisher,
+    prepare_event_subscriber,
+    prepare_rest_app,
+)
 
 
 async def run_rest_app():
@@ -43,3 +49,26 @@ async def consume_events(run_forever: bool = True):
 
     async with prepare_event_subscriber(config=config) as event_subscriber:
         await event_subscriber.run(forever=run_forever)
+
+
+async def publish_events(*, all: bool = False):
+    """Publish pending events. Set `--all` to (re)publish all events regardless of status."""
+    config = Config()  # type: ignore[call-arg]
+    configure_logging(config=config)
+
+    async with get_persistent_publisher(config=config) as persistent_publisher:
+        if all:
+            await persistent_publisher.republish()
+        else:
+            await persistent_publisher.publish_pending()
+
+    async with (
+        MongoKafkaDaoPublisherFactory.construct(config=config) as dao_publisher_factory,
+    ):
+        dao = await get_box_dao(
+            config=config, dao_publisher_factory=dao_publisher_factory
+        )
+        if all:
+            await dao.republish()
+        else:
+            await dao.publish_pending()

--- a/src/uos/main.py
+++ b/src/uos/main.py
@@ -22,6 +22,7 @@ Additional endpoints might be structured in dedicated modules
 
 from ghga_service_commons.api import run_server
 from hexkit.log import configure_logging
+from hexkit.opentelemetry import configure_opentelemetry
 from hexkit.providers.mongokafka import MongoKafkaDaoPublisherFactory
 
 from uos.adapters.outbound.dao import get_box_dao
@@ -37,6 +38,7 @@ async def run_rest_app():
     """Run the HTTP REST API."""
     config = Config()  # type: ignore [call-arg]
     configure_logging(config=config)
+    configure_opentelemetry(service_name=config.service_name, config=config)
 
     async with prepare_rest_app(config=config) as app:
         await run_server(app=app, config=config)
@@ -46,6 +48,7 @@ async def consume_events(run_forever: bool = True):
     """Run the event consumer"""
     config = Config()  # type: ignore[call-arg]
     configure_logging(config=config)
+    configure_opentelemetry(service_name=config.service_name, config=config)
 
     async with prepare_event_subscriber(config=config) as event_subscriber:
         await event_subscriber.run(forever=run_forever)
@@ -55,6 +58,7 @@ async def publish_events(*, all: bool = False):
     """Publish pending events. Set `--all` to (re)publish all events regardless of status."""
     config = Config()  # type: ignore[call-arg]
     configure_logging(config=config)
+    configure_opentelemetry(service_name=config.service_name, config=config)
 
     async with get_persistent_publisher(config=config) as persistent_publisher:
         if all:

--- a/src/uos/ports/inbound/orchestrator.py
+++ b/src/uos/ports/inbound/orchestrator.py
@@ -251,12 +251,13 @@ class UploadOrchestratorPort(ABC):
         - each file ID in the mapping exists in the retrieved list of files
         - all file IDs in the box are included in the mapping
 
-        Finally, store the mapping in the DB and publish an outbox event containing
-        the mapping field content.
+        Finally, submit the accession map to the Accession API and store it in the DB.
 
         Raises:
             BoxNotFoundError: If the box doesn't exist
             VersionError: If the requested ResearchDataUploadBox version is outdated
+            OperationError: If there's a problem submitting the accession map to the
+                Accession API
             AccessionMapError: If
             - the box is already archived, or
             - the accession map includes a file ID that doesn't exist in the box, or

--- a/src/uos/ports/inbound/orchestrator.py
+++ b/src/uos/ports/inbound/orchestrator.py
@@ -233,7 +233,7 @@ class UploadOrchestratorPort(ABC):
 
     @abstractmethod
     async def update_accession_map(
-        self, *, box_id: UUID4, request: AccessionMapRequest
+        self, *, box_id: UUID4, request: AccessionMapRequest, user_id: UUID4
     ) -> None:
         """Update the file accession map for a given box and publish an outbox event.
         This results in a version increment for the ResearchDataUploadBox.

--- a/src/uos/ports/outbound/dao.py
+++ b/src/uos/ports/outbound/dao.py
@@ -22,5 +22,5 @@ from uos.core.models import AccessionMap, ResearchDataUploadBox
 
 __all__ = ["AccessionMapDao", "BoxDao"]
 
-BoxDao = Dao[ResearchDataUploadBox]
-AccessionMapDao = DaoPublisher[AccessionMap]
+BoxDao = DaoPublisher[ResearchDataUploadBox]
+AccessionMapDao = Dao[AccessionMap]

--- a/src/uos/ports/outbound/http.py
+++ b/src/uos/ports/outbound/http.py
@@ -165,7 +165,9 @@ class AccessionClientPort(ABC):
         """Raised when there's an error while communicating with the service."""
 
     @abstractmethod
-    async def submit_accession_map(self, *, accession_map: AccessionMap) -> None:
+    async def submit_accession_map(
+        self, *, accession_map: AccessionMap, study_pid: str, user_id: UUID4
+    ) -> None:
         """Submit a map of accession numbers to file IDs.
 
         Raises:

--- a/src/uos/ports/outbound/http.py
+++ b/src/uos/ports/outbound/http.py
@@ -20,7 +20,7 @@ from abc import ABC, abstractmethod
 from ghga_service_commons.utils.utc_dates import UTCDatetime
 from pydantic import UUID4
 
-from uos.core.models import FileUploadWithAccession, UploadGrant
+from uos.core.models import AccessionMap, FileUploadWithAccession, UploadGrant
 
 
 class AccessClientPort(ABC):
@@ -150,5 +150,21 @@ class FileBoxClientPort(ABC):
         Raises:
             FUBVersionError if the remote box version differs from `version`.
             OperationError if there's any other problem with the operation.
+        """
+        ...
+
+
+class AccessionClientPort(ABC):
+    """An adapter for interacting with the service that manages accession numbers."""
+
+    class OperationError(RuntimeError):
+        """Raised when there's an error while communicating with the service."""
+
+    @abstractmethod
+    async def submit_accession_map(self, *, accession_map: AccessionMap) -> None:
+        """Submit a map of accession numbers to file IDs.
+
+        Raises:
+            OperationError: if there's a problem during the operation.
         """
         ...

--- a/src/uos/ports/outbound/http.py
+++ b/src/uos/ports/outbound/http.py
@@ -106,9 +106,7 @@ class FileBoxClientPort(ABC):
         """Raised when the requested version of a FileUploadBox is out of date."""
 
     @abstractmethod
-    async def create_file_upload_box(
-        self, *, storage_alias: str, user_id: UUID4
-    ) -> UUID4:
+    async def create_file_upload_box(self, *, storage_alias: str) -> UUID4:
         """Create a new FileUploadBox in owning service.
 
         Raises:
@@ -117,7 +115,7 @@ class FileBoxClientPort(ABC):
         ...
 
     @abstractmethod
-    async def lock_file_upload_box(self, *, box_id: UUID4, user_id: UUID4) -> None:
+    async def lock_file_upload_box(self, *, box_id: UUID4) -> None:
         """Lock a FileUploadBox in the owning service.
 
         Raises:
@@ -126,7 +124,7 @@ class FileBoxClientPort(ABC):
         ...
 
     @abstractmethod
-    async def unlock_file_upload_box(self, *, box_id: UUID4, user_id: UUID4) -> None:
+    async def unlock_file_upload_box(self, *, box_id: UUID4) -> None:
         """Unlock a FileUploadBox in the owning service.
 
         Raises:
@@ -136,7 +134,7 @@ class FileBoxClientPort(ABC):
 
     @abstractmethod
     async def get_file_upload_list(
-        self, *, box_id: UUID4, user_id: UUID4
+        self, *, box_id: UUID4
     ) -> list[FileUploadWithAccession]:
         """Get list of file uploads in a FileUploadBox.
 
@@ -146,9 +144,7 @@ class FileBoxClientPort(ABC):
         ...
 
     @abstractmethod
-    async def archive_file_upload_box(
-        self, *, box_id: UUID4, version: int, user_id: UUID4
-    ) -> None:
+    async def archive_file_upload_box(self, *, box_id: UUID4, version: int) -> None:
         """Archive a FileUploadBox in the owning service.
 
         Raises:

--- a/src/uos/ports/outbound/http.py
+++ b/src/uos/ports/outbound/http.py
@@ -20,7 +20,7 @@ from abc import ABC, abstractmethod
 from ghga_service_commons.utils.utc_dates import UTCDatetime
 from pydantic import UUID4
 
-from uos.core.models import AccessionMap, FileUploadWithAccession, UploadGrant
+from uos.core.models import PID, AccessionMap, FileUploadWithAccession, UploadGrant
 
 
 class AccessClientPort(ABC):
@@ -162,7 +162,7 @@ class AccessionClientPort(ABC):
 
     @abstractmethod
     async def submit_accession_map(
-        self, *, accession_map: AccessionMap, study_pid: str, user_id: UUID4
+        self, *, accession_map: AccessionMap, study_pid: PID, user_id: UUID4
     ) -> None:
         """Submit a map of accession numbers to file IDs.
 

--- a/src/uos/ports/outbound/http.py
+++ b/src/uos/ports/outbound/http.py
@@ -106,7 +106,9 @@ class FileBoxClientPort(ABC):
         """Raised when the requested version of a FileUploadBox is out of date."""
 
     @abstractmethod
-    async def create_file_upload_box(self, *, storage_alias: str) -> UUID4:
+    async def create_file_upload_box(
+        self, *, storage_alias: str, user_id: UUID4
+    ) -> UUID4:
         """Create a new FileUploadBox in owning service.
 
         Raises:
@@ -115,7 +117,7 @@ class FileBoxClientPort(ABC):
         ...
 
     @abstractmethod
-    async def lock_file_upload_box(self, *, box_id: UUID4) -> None:
+    async def lock_file_upload_box(self, *, box_id: UUID4, user_id: UUID4) -> None:
         """Lock a FileUploadBox in the owning service.
 
         Raises:
@@ -124,7 +126,7 @@ class FileBoxClientPort(ABC):
         ...
 
     @abstractmethod
-    async def unlock_file_upload_box(self, *, box_id: UUID4) -> None:
+    async def unlock_file_upload_box(self, *, box_id: UUID4, user_id: UUID4) -> None:
         """Unlock a FileUploadBox in the owning service.
 
         Raises:
@@ -134,7 +136,7 @@ class FileBoxClientPort(ABC):
 
     @abstractmethod
     async def get_file_upload_list(
-        self, *, box_id: UUID4
+        self, *, box_id: UUID4, user_id: UUID4
     ) -> list[FileUploadWithAccession]:
         """Get list of file uploads in a FileUploadBox.
 
@@ -144,7 +146,9 @@ class FileBoxClientPort(ABC):
         ...
 
     @abstractmethod
-    async def archive_file_upload_box(self, *, box_id: UUID4, version: int) -> None:
+    async def archive_file_upload_box(
+        self, *, box_id: UUID4, version: int, user_id: UUID4
+    ) -> None:
         """Archive a FileUploadBox in the owning service.
 
         Raises:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,11 +42,12 @@ from tests.fixtures.joint import joint_fixture  # noqa: F401
 @pytest.fixture(name="config")
 def config_fixture() -> ConfigFixture:
     """Generate config from test yaml along with an auth key and JWK"""
-    jwk = jwt_helpers.generate_jwk()
-    auth_key = jwk.export(private_key=False)
-    signing_key = jwt_helpers.generate_jwk().export_private()
-    config = get_config(auth_key=auth_key, work_order_signing_key=signing_key)
-    return ConfigFixture(config=config, jwk=jwk)
+    auth_jwk = jwt_helpers.generate_jwk()
+    auth_key = auth_jwk.export(private_key=False)
+    signing_jwk = jwt_helpers.generate_jwk()
+    jwt_signing_key = signing_jwk.export_private()
+    config = get_config(auth_key=auth_key, jwt_signing_key=jwt_signing_key)
+    return ConfigFixture(config=config, auth_jwk=auth_jwk, signing_jwk=signing_jwk)
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,8 +45,10 @@ def config_fixture() -> ConfigFixture:
     auth_jwk = jwt_helpers.generate_jwk()
     auth_key = auth_jwk.export(private_key=False)
     signing_jwk = jwt_helpers.generate_jwk()
-    jwt_signing_key = signing_jwk.export_private()
-    config = get_config(auth_key=auth_key, jwt_signing_key=jwt_signing_key)
+    work_order_signing_key = signing_jwk.export_private()
+    config = get_config(
+        auth_key=auth_key, work_order_signing_key=work_order_signing_key
+    )
     return ConfigFixture(config=config, auth_jwk=auth_jwk, signing_jwk=signing_jwk)
 
 

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -25,11 +25,13 @@ __all__ = ["ConfigFixture"]
 
 class ConfigFixture:
     config: Config
-    jwk: JWK
+    auth_jwk: JWK
+    signing_jwk: JWK
 
-    def __init__(self, *, config: Config, jwk: JWK):
+    def __init__(self, *, config: Config, auth_jwk: JWK, signing_jwk: JWK):
         self.config = config
-        self.jwk = jwk
+        self.auth_jwk = auth_jwk
+        self.signing_jwk = signing_jwk
 
     def update(self, **kwargs) -> Config:
         """Override specified values"""

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -43,7 +43,7 @@ class JointFixture:
     kafka: KafkaFixture
     mongodb: MongoDbFixture
     rest_client: AsyncTestClient
-    jwk: JWK
+    auth_jwk: JWK
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -80,5 +80,5 @@ async def joint_fixture(
             kafka=kafka,
             mongodb=mongodb,
             rest_client=rest_client,
-            jwk=config.jwk,
+            auth_jwk=config.auth_jwk,
         )

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -4,11 +4,11 @@ mongo_dsn: mongodb://localhost:27017
 db_name: uos
 mongo_timeout: 300
 auth_key: "{}"
-ucs_url: http://127.0.0.1/upload
 access_url: http://127.0.0.1/access
+ucs_url: http://127.0.0.1/upload
+accession_url: http://127.0.0.1/accession
 audit_record_topic: audit-records
 audit_record_type: audit_record_logged
 file_upload_box_topic: file-upload-boxes
 work_order_signing_key: "{}"
 research_data_upload_box_topic: research-data-upload-boxes
-accession_map_topic: accession-maps

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -10,5 +10,5 @@ accession_url: http://127.0.0.1/accession
 audit_record_topic: audit-records
 audit_record_type: audit_record_logged
 file_upload_box_topic: file-upload-boxes
-jwt_signing_key: "{}"
+work_order_signing_key: "{}"
 research_data_upload_box_topic: research-data-upload-boxes

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -10,5 +10,5 @@ accession_url: http://127.0.0.1/accession
 audit_record_topic: audit-records
 audit_record_type: audit_record_logged
 file_upload_box_topic: file-upload-boxes
-work_order_signing_key: "{}"
+jwt_signing_key: "{}"
 research_data_upload_box_topic: research-data-upload-boxes

--- a/tests/integration/test_typical_journey.py
+++ b/tests/integration/test_typical_journey.py
@@ -207,7 +207,6 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
     assert box_after_lock.state == box_after_lock.file_upload_box_state == "locked"
     assert box_after_lock.version == 3
 
-    # Submit accession map
     # Create test file IDs for files in the box
     file_id_1 = uuid4()
     file_id_2 = uuid4()
@@ -263,20 +262,14 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
         version=box_after_lock.version,
         mapping={"GHGA001": file_id_1, "GHGA002": file_id_2, "GHGA003": file_id_3},
     )
-    async with joint_fixture.kafka.record_events(
-        in_topic=joint_fixture.config.accession_map_topic
-    ) as accession_event_recorder:
-        await orchestrator.update_accession_map(box_id=box_id, request=accession_map)
-
-    # Verify the updated accession map was published
-    assert accession_event_recorder.recorded_events
-    assert len(accession_event_recorder.recorded_events) == 1
-    accession_map_event = accession_event_recorder.recorded_events[0]
-    assert accession_map_event.type_ == "upserted"
-    assert accession_map_event.key == str(box_id)
-    assert (
-        accession_map_event.payload == accession_map.model_dump(mode="json")["mapping"]
+    # Mock the endpoint of the Accession API
+    accession_url = joint_fixture.config.accession_url
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{accession_url}/accession-map",
+        status_code=204,
     )
+    await orchestrator.update_accession_map(box_id=box_id, request=accession_map)
 
     # Make sure the RDUB version was bumped by the accession map update
     box_after_mapping = await orchestrator.get_research_data_upload_box(

--- a/tests/integration/test_typical_journey.py
+++ b/tests/integration/test_typical_journey.py
@@ -269,7 +269,9 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
         url=f"{accession_url}/file-ids",
         status_code=204,
     )
-    await orchestrator.update_accession_map(box_id=box_id, request=accession_map)
+    await orchestrator.update_accession_map(
+        box_id=box_id, request=accession_map, user_id=ds_user_id
+    )
 
     # Make sure the RDUB version was bumped by the accession map update
     box_after_mapping = await orchestrator.get_research_data_upload_box(

--- a/tests/integration/test_typical_journey.py
+++ b/tests/integration/test_typical_journey.py
@@ -258,16 +258,17 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
     )
 
     # Submit an accession map
+    study_pid = "GHGA-STUDY-001"
     accession_map = AccessionMapRequest(
         version=box_after_lock.version,
         mapping={"GHGA001": file_id_1, "GHGA002": file_id_2, "GHGA003": file_id_3},
-        study_pid="GHGA-STUDY-001",
+        study_pid=study_pid,
     )
     # Mock the endpoint of the Accession API
     accession_url = joint_fixture.config.accession_url
     httpx_mock.add_response(
         method="POST",
-        url=f"{accession_url}/file-ids",
+        url=f"{accession_url}/file-ids/{study_pid}",
         status_code=204,
     )
     await orchestrator.update_accession_map(

--- a/tests/integration/test_typical_journey.py
+++ b/tests/integration/test_typical_journey.py
@@ -266,7 +266,7 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
     accession_url = joint_fixture.config.accession_url
     httpx_mock.add_response(
         method="POST",
-        url=f"{accession_url}/accession-maps",
+        url=f"{accession_url}/file-ids",
         status_code=204,
     )
     await orchestrator.update_accession_map(box_id=box_id, request=accession_map)

--- a/tests/integration/test_typical_journey.py
+++ b/tests/integration/test_typical_journey.py
@@ -261,6 +261,7 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
     accession_map = AccessionMapRequest(
         version=box_after_lock.version,
         mapping={"GHGA001": file_id_1, "GHGA002": file_id_2, "GHGA003": file_id_3},
+        study_pid="GHGA-STUDY-001",
     )
     # Mock the endpoint of the Accession API
     accession_url = joint_fixture.config.accession_url

--- a/tests/integration/test_typical_journey.py
+++ b/tests/integration/test_typical_journey.py
@@ -266,7 +266,7 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
     accession_url = joint_fixture.config.accession_url
     httpx_mock.add_response(
         method="POST",
-        url=f"{accession_url}/accession-map",
+        url=f"{accession_url}/accession-maps",
         status_code=204,
     )
     await orchestrator.update_accession_map(box_id=box_id, request=accession_map)

--- a/tests/unit/test_accession_client.py
+++ b/tests/unit/test_accession_client.py
@@ -1,0 +1,64 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the AccessionClient"""
+
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from tests.fixtures import ConfigFixture
+from uos.adapters.outbound.http import AccessionClient
+from uos.core.models import AccessionMap
+
+pytestmark = pytest.mark.asyncio
+
+TEST_BOX_ID = UUID("a1b2c3d4-e5f6-4890-abcd-ef1234567890")
+
+ACCESSION_MAP = AccessionMap(
+    box_id=TEST_BOX_ID,
+    mapping={"GHGA:file1": uuid4(), "GHGA:file2": uuid4()},
+)
+
+
+async def test_submission(
+    config: ConfigFixture, httpx_mock: HTTPXMock, httpx_client: httpx.AsyncClient
+):
+    """Test that the AccessionClient sends a request to the right URL with the right
+    payload given an AccessionMap.
+    """
+    accession_client = AccessionClient(config=config.config, httpx_client=httpx_client)
+
+    # Happy path
+    httpx_mock.add_response(204)
+    await accession_client.submit_accession_map(
+        accession_map=ACCESSION_MAP
+    )  # no error == success
+
+    # Check off-normal status code
+    httpx_mock.add_response(500, json={"error": "Some error occurred."})
+    with pytest.raises(AccessionClient.OperationError):
+        await accession_client.submit_accession_map(accession_map=ACCESSION_MAP)
+
+    # Check 400 status code
+    httpx_mock.add_response(400, json={"error": "Bad request"})
+    with pytest.raises(AccessionClient.OperationError):
+        await accession_client.submit_accession_map(accession_map=ACCESSION_MAP)
+
+    # Check 404 status code
+    httpx_mock.add_response(404, json={"error": "Not found"})
+    with pytest.raises(AccessionClient.OperationError):
+        await accession_client.submit_accession_map(accession_map=ACCESSION_MAP)

--- a/tests/unit/test_accession_client.py
+++ b/tests/unit/test_accession_client.py
@@ -14,14 +14,21 @@
 # limitations under the License.
 """Unit tests for the AccessionClient"""
 
+from datetime import timedelta
+from typing import Literal, cast
 from uuid import UUID, uuid4
 
 import httpx
 import pytest
+from ghga_service_commons.auth.jwt_auth import JWTAuthConfig, JWTAuthContextProvider
+from ghga_service_commons.utils.utc_dates import UTCDatetime
+from hexkit.utils import now_utc_ms_prec
+from pydantic import BaseModel
 from pytest_httpx import HTTPXMock
 
 from tests.fixtures import ConfigFixture
 from uos.adapters.outbound.http import AccessionClient
+from uos.constants import JWT_ISS, JWT_SUB
 from uos.core.models import AccessionMap
 
 pytestmark = pytest.mark.asyncio
@@ -32,6 +39,16 @@ ACCESSION_MAP = AccessionMap(
     box_id=TEST_BOX_ID,
     mapping={"GHGA:file1": uuid4(), "GHGA:file2": uuid4()},
 )
+
+
+class JWTClaimsModel(BaseModel):
+    """Model which defines the expected JWT format"""
+
+    aud: Literal["GHGA"]
+    iss: Literal["GHGA"]
+    sub: str
+    iat: UTCDatetime
+    exp: UTCDatetime
 
 
 async def test_submission(
@@ -62,3 +79,34 @@ async def test_submission(
     httpx_mock.add_response(404, json={"error": "Not found"})
     with pytest.raises(AccessionClient.OperationError):
         await accession_client.submit_accession_map(accession_map=ACCESSION_MAP)
+
+
+async def test_jwt_formation(
+    config: ConfigFixture, httpx_mock: HTTPXMock, httpx_client: httpx.AsyncClient
+):
+    """Test that the AccessionClient class formulates proper JWTs"""
+    # Create a mock JWTAuthContextProvider so we can inspect the JWT sent by this service
+    accession_api_auth_config = JWTAuthConfig(
+        auth_key=config.signing_jwk.export_public(),
+        auth_check_claims=dict.fromkeys(["iss", "iat", "sub", "aud", "exp"]),
+    )
+    auth_context_provider = JWTAuthContextProvider(
+        config=accession_api_auth_config, context_class=JWTClaimsModel
+    )
+
+    # Define a callback that can inspect the request from the accession client
+    async def callback(request: httpx.Request):
+        """Callback function that decrypts the JWT in the bearer token"""
+        token = cast(str, request.headers.get("Authorization"))
+        token = token.removeprefix("Bearer ")
+        context = await auth_context_provider.get_context(token)
+        assert context
+        assert context.iss == context.aud == JWT_ISS
+        assert context.sub == JWT_SUB
+        assert context.iat - now_utc_ms_prec() < timedelta(seconds=3)
+        return httpx.Response(204)
+
+    # Register the callback
+    httpx_mock.add_callback(callback=callback)
+    accession_client = AccessionClient(config=config.config, httpx_client=httpx_client)
+    await accession_client.submit_accession_map(accession_map=ACCESSION_MAP)

--- a/tests/unit/test_accession_client.py
+++ b/tests/unit/test_accession_client.py
@@ -47,6 +47,7 @@ class WOTClaimsModel(BaseModel):
 
     work_type: Literal["map"]
     user_id: UUID4
+    study_pid: str
     iat: UTCDatetime
     exp: UTCDatetime
 
@@ -81,7 +82,9 @@ async def test_wot_formation(
     """
     auth_config = JWTAuthConfig(
         auth_key=config.signing_jwk.export_public(),
-        auth_check_claims=dict.fromkeys(["work_type", "user_id", "iat", "exp"]),
+        auth_check_claims=dict.fromkeys(
+            ["work_type", "user_id", "study_pid", "iat", "exp"]
+        ),
     )
     auth_context_provider = JWTAuthContextProvider(
         config=auth_config, context_class=WOTClaimsModel
@@ -95,6 +98,7 @@ async def test_wot_formation(
         assert context
         assert context.work_type == "map"
         assert context.user_id == test_user_id
+        assert context.study_pid == TEST_STUDY_PID
         assert context.iat - now_utc_ms_prec() < timedelta(seconds=3)
         body = json.loads(request.content)
         assert body["study_pid"] == TEST_STUDY_PID

--- a/tests/unit/test_accession_client.py
+++ b/tests/unit/test_accession_client.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Unit tests for the AccessionClient"""
 
+import json
 from datetime import timedelta
 from typing import Literal, cast
 from uuid import UUID, uuid4
@@ -23,17 +24,17 @@ import pytest
 from ghga_service_commons.auth.jwt_auth import JWTAuthConfig, JWTAuthContextProvider
 from ghga_service_commons.utils.utc_dates import UTCDatetime
 from hexkit.utils import now_utc_ms_prec
-from pydantic import BaseModel
+from pydantic import UUID4, BaseModel
 from pytest_httpx import HTTPXMock
 
 from tests.fixtures import ConfigFixture
 from uos.adapters.outbound.http import AccessionClient
-from uos.constants import JWT_ISS, JWT_SUB
 from uos.core.models import AccessionMap
 
 pytestmark = pytest.mark.asyncio
 
 TEST_BOX_ID = UUID("a1b2c3d4-e5f6-4890-abcd-ef1234567890")
+TEST_STUDY_PID = "GHGA-STUDY-001"
 
 ACCESSION_MAP = AccessionMap(
     box_id=TEST_BOX_ID,
@@ -41,12 +42,11 @@ ACCESSION_MAP = AccessionMap(
 )
 
 
-class JWTClaimsModel(BaseModel):
-    """Model which defines the expected JWT format"""
+class WOTClaimsModel(BaseModel):
+    """Model which defines the expected WOT format for accession map submission"""
 
-    aud: Literal["GHGA"]
-    iss: Literal["GHGA"]
-    sub: str
+    work_type: Literal["map"]
+    user_id: UUID4
     iat: UTCDatetime
     exp: UTCDatetime
 
@@ -58,43 +58,50 @@ async def test_submission(
     payload given an AccessionMap.
     """
     accession_client = AccessionClient(config=config.config, httpx_client=httpx_client)
+    test_user_id = uuid4()
 
-    # Should see
     httpx_mock.add_response(204)
-    await accession_client.submit_accession_map(accession_map=ACCESSION_MAP)
+    await accession_client.submit_accession_map(
+        accession_map=ACCESSION_MAP, study_pid=TEST_STUDY_PID, user_id=test_user_id
+    )
 
     # Check off-normal status code
     httpx_mock.add_response(500, json={"error": "Some error occurred."})
     with pytest.raises(AccessionClient.OperationError):
-        await accession_client.submit_accession_map(accession_map=ACCESSION_MAP)
+        await accession_client.submit_accession_map(
+            accession_map=ACCESSION_MAP, study_pid=TEST_STUDY_PID, user_id=test_user_id
+        )
 
 
-async def test_jwt_formation(
+async def test_wot_formation(
     config: ConfigFixture, httpx_mock: HTTPXMock, httpx_client: httpx.AsyncClient
 ):
-    """Test that the AccessionClient class formulates proper JWTs"""
-    # Create a mock JWTAuthContextProvider so we can inspect the JWT sent by this service
-    accession_api_auth_config = JWTAuthConfig(
+    """Test that the AccessionClient sends a properly formed work order token and
+    includes study_pid in the request body.
+    """
+    auth_config = JWTAuthConfig(
         auth_key=config.signing_jwk.export_public(),
-        auth_check_claims=dict.fromkeys(["iss", "iat", "sub", "aud", "exp"]),
+        auth_check_claims=dict.fromkeys(["work_type", "user_id", "iat", "exp"]),
     )
     auth_context_provider = JWTAuthContextProvider(
-        config=accession_api_auth_config, context_class=JWTClaimsModel
+        config=auth_config, context_class=WOTClaimsModel
     )
+    test_user_id = uuid4()
 
-    # Define a callback that can inspect the request from the accession client
     async def callback(request: httpx.Request):
-        """Callback function that decrypts the JWT in the bearer token"""
         token = cast(str, request.headers.get("Authorization"))
         token = token.removeprefix("Bearer ")
         context = await auth_context_provider.get_context(token)
         assert context
-        assert context.iss == context.aud == JWT_ISS
-        assert context.sub == JWT_SUB
+        assert context.work_type == "map"
+        assert context.user_id == test_user_id
         assert context.iat - now_utc_ms_prec() < timedelta(seconds=3)
+        body = json.loads(request.content)
+        assert body["study_pid"] == TEST_STUDY_PID
         return httpx.Response(204)
 
-    # Register the callback
     httpx_mock.add_callback(callback=callback)
     accession_client = AccessionClient(config=config.config, httpx_client=httpx_client)
-    await accession_client.submit_accession_map(accession_map=ACCESSION_MAP)
+    await accession_client.submit_accession_map(
+        accession_map=ACCESSION_MAP, study_pid=TEST_STUDY_PID, user_id=test_user_id
+    )

--- a/tests/unit/test_accession_client.py
+++ b/tests/unit/test_accession_client.py
@@ -59,24 +59,12 @@ async def test_submission(
     """
     accession_client = AccessionClient(config=config.config, httpx_client=httpx_client)
 
-    # Happy path
+    # Should see
     httpx_mock.add_response(204)
-    await accession_client.submit_accession_map(
-        accession_map=ACCESSION_MAP
-    )  # no error == success
+    await accession_client.submit_accession_map(accession_map=ACCESSION_MAP)
 
     # Check off-normal status code
     httpx_mock.add_response(500, json={"error": "Some error occurred."})
-    with pytest.raises(AccessionClient.OperationError):
-        await accession_client.submit_accession_map(accession_map=ACCESSION_MAP)
-
-    # Check 400 status code
-    httpx_mock.add_response(400, json={"error": "Bad request"})
-    with pytest.raises(AccessionClient.OperationError):
-        await accession_client.submit_accession_map(accession_map=ACCESSION_MAP)
-
-    # Check 404 status code
-    httpx_mock.add_response(404, json={"error": "Not found"})
     with pytest.raises(AccessionClient.OperationError):
         await accession_client.submit_accession_map(accession_map=ACCESSION_MAP)
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -58,14 +58,14 @@ def headers_for_token(token: str) -> dict[str, str]:
 @pytest.fixture(name="user_auth_headers")
 def fixture_user_auth_headers(config: ConfigFixture) -> dict[str, str]:
     """Get auth headers for testing"""
-    token = sign_and_serialize_token(USER_AUTH_CLAIMS, config.jwk)
+    token = sign_and_serialize_token(USER_AUTH_CLAIMS, config.auth_jwk)
     return headers_for_token(token)
 
 
 @pytest.fixture(name="ds_auth_headers")
 def fixture_ds_auth_headers(config: ConfigFixture) -> dict[str, str]:
     """Get auth headers for testing"""
-    token = sign_and_serialize_token(DS_AUTH_CLAIMS, config.jwk)
+    token = sign_and_serialize_token(DS_AUTH_CLAIMS, config.auth_jwk)
     return headers_for_token(token)
 
 
@@ -74,7 +74,7 @@ def fixture_bad_auth_headers(config: ConfigFixture) -> dict[str, str]:
     """Get a invalid auth headers for testing"""
     claims = DS_AUTH_CLAIMS.copy()
     del claims["id"]
-    token = sign_and_serialize_token(claims, config.jwk)
+    token = sign_and_serialize_token(claims, config.auth_jwk)
     return headers_for_token(token)
 
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -762,6 +762,7 @@ async def test_submit_accession_map(
         request_data = {
             "version": 0,
             "mapping": {"GHGA001": str(uuid4()), "GHGA002": str(uuid4())},
+            "study_pid": "GHGA-STUDY-001",
         }
 
         # unauthenticated

--- a/tests/unit/test_file_box_client.py
+++ b/tests/unit/test_file_box_client.py
@@ -38,26 +38,19 @@ async def test_create_file_upload_box(
     file_upload_box_client = FileBoxClient(
         config=config.config, httpx_client=httpx_client
     )
-    test_user_id = uuid4()
     httpx_mock.add_response(201, json=str(TEST_BOX_ID))
-    box_id = await file_upload_box_client.create_file_upload_box(
-        storage_alias="HD01", user_id=test_user_id
-    )
+    box_id = await file_upload_box_client.create_file_upload_box(storage_alias="HD01")
     assert box_id == TEST_BOX_ID, "Failed happy path"
 
     # Check off-normal status code
     httpx_mock.add_response(500, json="Some error occurred.")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.create_file_upload_box(
-            storage_alias="HD01", user_id=test_user_id
-        )
+        await file_upload_box_client.create_file_upload_box(storage_alias="HD01")
 
     # Check with successful status code but garbled response body
     httpx_mock.add_response(201, json="id123")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.create_file_upload_box(
-            storage_alias="HD01", user_id=test_user_id
-        )
+        await file_upload_box_client.create_file_upload_box(storage_alias="HD01")
 
 
 async def test_lock_file_upload_box(
@@ -67,18 +60,15 @@ async def test_lock_file_upload_box(
     file_upload_box_client = FileBoxClient(
         config=config.config, httpx_client=httpx_client
     )
-    test_user_id = uuid4()
     httpx_mock.add_response(204)
     await file_upload_box_client.lock_file_upload_box(
-        box_id=TEST_BOX_ID, user_id=test_user_id
+        box_id=TEST_BOX_ID
     )  # no error == success
 
     # Check off-normal status code
     httpx_mock.add_response(500, json="Some error occurred.")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.lock_file_upload_box(
-            box_id=TEST_BOX_ID, user_id=test_user_id
-        )
+        await file_upload_box_client.lock_file_upload_box(box_id=TEST_BOX_ID)
 
 
 async def test_unlock_file_upload_box(
@@ -88,18 +78,15 @@ async def test_unlock_file_upload_box(
     file_upload_box_client = FileBoxClient(
         config=config.config, httpx_client=httpx_client
     )
-    test_user_id = uuid4()
     httpx_mock.add_response(204)
     await file_upload_box_client.unlock_file_upload_box(
-        box_id=TEST_BOX_ID, user_id=test_user_id
+        box_id=TEST_BOX_ID
     )  # no error == success
 
     # Check off-normal status code
     httpx_mock.add_response(500, json="Some error occurred.")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.unlock_file_upload_box(
-            box_id=TEST_BOX_ID, user_id=test_user_id
-        )
+        await file_upload_box_client.unlock_file_upload_box(box_id=TEST_BOX_ID)
 
 
 async def test_get_file_upload_list(
@@ -124,32 +111,23 @@ async def test_get_file_upload_list(
         )
         for i in range(3)
     ]
-    test_user_id = uuid4()
     httpx_mock.add_response(
         200, json=[x.model_dump(mode="json") for x in file_list_response]
     )
-    file_list = await file_upload_box_client.get_file_upload_list(
-        box_id=TEST_BOX_ID, user_id=test_user_id
-    )
+    file_list = await file_upload_box_client.get_file_upload_list(box_id=TEST_BOX_ID)
     assert file_list == file_list_response
 
     # Check off-normal status code
     httpx_mock.add_response(500, json="Some error occurred.")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.get_file_upload_list(
-            box_id=TEST_BOX_ID, user_id=test_user_id
-        )
+        await file_upload_box_client.get_file_upload_list(box_id=TEST_BOX_ID)
 
     # Check with successful status code but garbled response body
     httpx_mock.add_response(200, json="id123")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.get_file_upload_list(
-            box_id=TEST_BOX_ID, user_id=test_user_id
-        )
+        await file_upload_box_client.get_file_upload_list(box_id=TEST_BOX_ID)
 
     # Check with empty list response
     httpx_mock.add_response(200, json=[])
-    file_list = await file_upload_box_client.get_file_upload_list(
-        box_id=TEST_BOX_ID, user_id=test_user_id
-    )
+    file_list = await file_upload_box_client.get_file_upload_list(box_id=TEST_BOX_ID)
     assert file_list == []

--- a/tests/unit/test_file_box_client.py
+++ b/tests/unit/test_file_box_client.py
@@ -38,19 +38,26 @@ async def test_create_file_upload_box(
     file_upload_box_client = FileBoxClient(
         config=config.config, httpx_client=httpx_client
     )
+    test_user_id = uuid4()
     httpx_mock.add_response(201, json=str(TEST_BOX_ID))
-    box_id = await file_upload_box_client.create_file_upload_box(storage_alias="HD01")
+    box_id = await file_upload_box_client.create_file_upload_box(
+        storage_alias="HD01", user_id=test_user_id
+    )
     assert box_id == TEST_BOX_ID, "Failed happy path"
 
     # Check off-normal status code
     httpx_mock.add_response(500, json="Some error occurred.")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.create_file_upload_box(storage_alias="HD01")
+        await file_upload_box_client.create_file_upload_box(
+            storage_alias="HD01", user_id=test_user_id
+        )
 
     # Check with successful status code but garbled response body
     httpx_mock.add_response(201, json="id123")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.create_file_upload_box(storage_alias="HD01")
+        await file_upload_box_client.create_file_upload_box(
+            storage_alias="HD01", user_id=test_user_id
+        )
 
 
 async def test_lock_file_upload_box(
@@ -60,15 +67,18 @@ async def test_lock_file_upload_box(
     file_upload_box_client = FileBoxClient(
         config=config.config, httpx_client=httpx_client
     )
+    test_user_id = uuid4()
     httpx_mock.add_response(204)
     await file_upload_box_client.lock_file_upload_box(
-        box_id=TEST_BOX_ID
+        box_id=TEST_BOX_ID, user_id=test_user_id
     )  # no error == success
 
     # Check off-normal status code
     httpx_mock.add_response(500, json="Some error occurred.")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.lock_file_upload_box(box_id=TEST_BOX_ID)
+        await file_upload_box_client.lock_file_upload_box(
+            box_id=TEST_BOX_ID, user_id=test_user_id
+        )
 
 
 async def test_unlock_file_upload_box(
@@ -78,15 +88,18 @@ async def test_unlock_file_upload_box(
     file_upload_box_client = FileBoxClient(
         config=config.config, httpx_client=httpx_client
     )
+    test_user_id = uuid4()
     httpx_mock.add_response(204)
     await file_upload_box_client.unlock_file_upload_box(
-        box_id=TEST_BOX_ID
+        box_id=TEST_BOX_ID, user_id=test_user_id
     )  # no error == success
 
     # Check off-normal status code
     httpx_mock.add_response(500, json="Some error occurred.")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.unlock_file_upload_box(box_id=TEST_BOX_ID)
+        await file_upload_box_client.unlock_file_upload_box(
+            box_id=TEST_BOX_ID, user_id=test_user_id
+        )
 
 
 async def test_get_file_upload_list(
@@ -111,23 +124,32 @@ async def test_get_file_upload_list(
         )
         for i in range(3)
     ]
+    test_user_id = uuid4()
     httpx_mock.add_response(
         200, json=[x.model_dump(mode="json") for x in file_list_response]
     )
-    file_list = await file_upload_box_client.get_file_upload_list(box_id=TEST_BOX_ID)
+    file_list = await file_upload_box_client.get_file_upload_list(
+        box_id=TEST_BOX_ID, user_id=test_user_id
+    )
     assert file_list == file_list_response
 
     # Check off-normal status code
     httpx_mock.add_response(500, json="Some error occurred.")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.get_file_upload_list(box_id=TEST_BOX_ID)
+        await file_upload_box_client.get_file_upload_list(
+            box_id=TEST_BOX_ID, user_id=test_user_id
+        )
 
     # Check with successful status code but garbled response body
     httpx_mock.add_response(200, json="id123")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.get_file_upload_list(box_id=TEST_BOX_ID)
+        await file_upload_box_client.get_file_upload_list(
+            box_id=TEST_BOX_ID, user_id=test_user_id
+        )
 
     # Check with empty list response
     httpx_mock.add_response(200, json=[])
-    file_list = await file_upload_box_client.get_file_upload_list(box_id=TEST_BOX_ID)
+    file_list = await file_upload_box_client.get_file_upload_list(
+        box_id=TEST_BOX_ID, user_id=test_user_id
+    )
     assert file_list == []

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,47 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for core data models"""
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from uos.core.models import PID
+
+
+class _PIDModel(BaseModel):
+    value: PID
+
+
+def test_pid_valid_ascii():
+    """A normal ASCII string is accepted."""
+    assert _PIDModel(value="GHGA-STUDY-001").value == "GHGA-STUDY-001"
+
+
+def test_pid_max_length_boundary():
+    """A string of exactly 256 ASCII characters is accepted."""
+    assert _PIDModel(value="x" * 256).value == "x" * 256
+
+
+def test_pid_too_long():
+    """A string exceeding 256 characters is rejected."""
+    with pytest.raises(ValidationError):
+        _PIDModel(value="x" * 257)
+
+
+def test_pid_non_ascii():
+    """A string containing non-ASCII characters is rejected."""
+    with pytest.raises(ValidationError):
+        _PIDModel(value="GHGA-STUDY-\u00fc01")  # ü is non-ASCII

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -31,7 +31,11 @@ from tests.fixtures import ConfigFixture
 from uos.config import Config
 from uos.core import models
 from uos.core.orchestrator import UploadOrchestrator
-from uos.ports.outbound.http import AccessClientPort, FileBoxClientPort
+from uos.ports.outbound.http import (
+    AccessClientPort,
+    AccessionClientPort,
+    FileBoxClientPort,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -63,6 +67,7 @@ class JointRig:
     accession_map_dao: BaseInMemDao[models.AccessionMap]
     file_upload_box_client: FileBoxClientPort
     access_client: AccessClientPort
+    accession_client: AccessionClientPort
     controller: UploadOrchestrator
 
 
@@ -78,12 +83,14 @@ def rig(config: ConfigFixture) -> JointRig:
     file_box_client_mock = AsyncMock()
     file_box_client_mock.create_file_upload_box = file_upload_box_id_generator
     access_client_mock = AsyncMock()
+    accession_client_mock = AsyncMock()
 
     controller = UploadOrchestrator(
         box_dao=(box_dao := InMemBoxDao()),  # type: ignore
         accession_map_dao=(accession_map_dao := InMemAccessionMapDao()),  # type: ignore
         file_upload_box_client=file_box_client_mock,
         access_client=access_client_mock,
+        accession_client=accession_client_mock,
         audit_repository=AsyncMock(),
     )
 
@@ -93,6 +100,7 @@ def rig(config: ConfigFixture) -> JointRig:
         accession_map_dao=accession_map_dao,
         file_upload_box_client=file_box_client_mock,
         access_client=access_client_mock,
+        accession_client=accession_client_mock,
         controller=controller,
     )
 
@@ -696,6 +704,9 @@ async def test_update_accession_map_happy(rig: JointRig, populated_boxes: list[U
     with pytest.raises(rig.controller.BoxNotFoundError):
         await rig.controller.update_accession_map(box_id=uuid4(), request=accession_map)
 
+    # Verify that the accession client was not called
+    rig.accession_client.submit_accession_map.assert_not_called()  # type: ignore
+
     # Verify file box client was not called
     rig.file_upload_box_client.get_file_upload_list.assert_not_called()  # type: ignore
 
@@ -714,6 +725,9 @@ async def test_update_accession_map_happy(rig: JointRig, populated_boxes: list[U
     # Verify the research data upload box version was incremented
     box = await rig.box_dao.get_by_id(box_id)
     assert box.version - version_pre_update == 1
+
+    # Verify that the accession client was called
+    rig.accession_client.submit_accession_map.assert_called_once()  # type: ignore
 
     # Verify file box client was called
     rig.file_upload_box_client.get_file_upload_list.assert_called_once()  # type: ignore

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -702,7 +702,9 @@ async def test_update_accession_map_happy(rig: JointRig, populated_boxes: list[U
 
     # Verify that a BoxNotFoundError is raised for a non-existent box
     with pytest.raises(rig.controller.BoxNotFoundError):
-        await rig.controller.update_accession_map(box_id=uuid4(), request=accession_map)
+        await rig.controller.update_accession_map(
+            box_id=uuid4(), request=accession_map, user_id=TEST_DS_ID
+        )
 
     # Verify that the accession client was not called
     rig.accession_client.submit_accession_map.assert_not_called()  # type: ignore
@@ -715,7 +717,9 @@ async def test_update_accession_map_happy(rig: JointRig, populated_boxes: list[U
     version_pre_update = box.version
 
     # Call the method with the valid map now
-    await rig.controller.update_accession_map(box_id=box_id, request=accession_map)
+    await rig.controller.update_accession_map(
+        box_id=box_id, request=accession_map, user_id=TEST_DS_ID
+    )
 
     # Verify the accession map was stored
     stored_map = await rig.accession_map_dao.get_by_id(box_id)
@@ -770,7 +774,9 @@ async def test_update_accession_map_invalid_or_unmapped_file_ids(
 
     # Should raise AccessionMapError
     with pytest.raises(rig.controller.AccessionMapError, match="not in the box"):
-        await rig.controller.update_accession_map(box_id=box_id, request=accession_map)
+        await rig.controller.update_accession_map(
+            box_id=box_id, request=accession_map, user_id=TEST_DS_ID
+        )
 
     # Verify file box client was called
     rig.file_upload_box_client.get_file_upload_list.assert_called_once()  # type: ignore
@@ -784,7 +790,9 @@ async def test_update_accession_map_invalid_or_unmapped_file_ids(
     with pytest.raises(
         rig.controller.AccessionMapError, match="still need to be mapped"
     ):
-        await rig.controller.update_accession_map(box_id=box_id, request=accession_map)
+        await rig.controller.update_accession_map(
+            box_id=box_id, request=accession_map, user_id=TEST_DS_ID
+        )
 
 
 async def test_update_accession_map_filters_cancelled_and_failed(
@@ -855,7 +863,9 @@ async def test_update_accession_map_filters_cancelled_and_failed(
     )
 
     # This should succeed because cancelled and failed files are ignored
-    await rig.controller.update_accession_map(box_id=box_id, request=request)
+    await rig.controller.update_accession_map(
+        box_id=box_id, request=request, user_id=TEST_DS_ID
+    )
 
     # Verify the accession map was stored
     stored_map = await rig.accession_map_dao.get_by_id(box_id)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -698,6 +698,7 @@ async def test_update_accession_map_happy(rig: JointRig, populated_boxes: list[U
             "GHGA002": test_file_ids[1],
             "GHGA003": test_file_ids[2],
         },
+        study_pid="GHGA-STUDY-001",
     )
 
     # Verify that a BoxNotFoundError is raised for a non-existent box
@@ -769,7 +770,9 @@ async def test_update_accession_map_invalid_or_unmapped_file_ids(
     # Create an accession map with a file ID that doesn't exist in the box
     invalid_file_id = uuid4()
     accession_map = models.AccessionMapRequest(
-        version=0, mapping={"GHGA001": test_file_ids[0], "GHGA002": invalid_file_id}
+        version=0,
+        mapping={"GHGA001": test_file_ids[0], "GHGA002": invalid_file_id},
+        study_pid="GHGA-STUDY-001",
     )
 
     # Should raise AccessionMapError
@@ -783,7 +786,7 @@ async def test_update_accession_map_invalid_or_unmapped_file_ids(
 
     # Create an accession map that omits a file
     accession_map = models.AccessionMapRequest(
-        version=0, mapping={"GHGA001": test_file_ids[0]}
+        version=0, mapping={"GHGA001": test_file_ids[0]}, study_pid="GHGA-STUDY-001"
     )
 
     # Should raise AccessionMapError
@@ -859,7 +862,9 @@ async def test_update_accession_map_filters_cancelled_and_failed(
 
     # Create an accession map for only the valid files
     request = models.AccessionMapRequest(
-        version=0, mapping={"GHGA001": test_file_ids[0], "GHGA004": test_file_ids[3]}
+        version=0,
+        mapping={"GHGA001": test_file_ids[0], "GHGA004": test_file_ids[3]},
+        study_pid="GHGA-STUDY-001",
     )
 
     # This should succeed because cancelled and failed files are ignored


### PR DESCRIPTION
Removes the outbox publisher for accession maps, converts the dao to a standard dao, and adds an `AccessionClient` to submit accession maps to the accession store/study registry.