### PR TITLE
Fix the FUB update requests and testing for it

### DIFF
--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -320,22 +320,37 @@ class FileBoxClient(FileBoxClientPort):
             log.error(msg, exc_info=True)
             raise self.OperationError(msg) from err
 
-    async def lock_file_upload_box(self, *, box_id: UUID4) -> None:
+    async def lock_file_upload_box(self, *, box_id: UUID4, version: int) -> None:
         """Lock a FileUploadBox in the owning service.
 
         Raises:
+            FUBVersionError if the remote box version differs from `version`.
             OperationError if there's a problem with the operation.
         """
         wot = ChangeFileBoxWorkOrder(work_type="lock", box_id=box_id)
         headers = self._auth_header(wot)
-        body = {"lock": True}
+        body = {"version": version, "state": "locked"}
         response = await self._client.patch(
             f"{self._ucs_url}/boxes/{box_id}",
             headers=headers,
             json=body,
             timeout=HTTPX_TIMEOUT,
         )
-        if response.status_code != 204:
+        if response.status_code == 409:
+            log.error(
+                "Failed to archive FileUploadBox %s because the version specified"
+                + " in the request is out of date.",
+                box_id,
+                extra={
+                    "box_id": box_id,
+                    "version": version,
+                    "response_text": response.text,
+                },
+            )
+            raise self.FUBVersionError(
+                "Requested FileUploadBox version is out of date."
+            )
+        elif response.status_code != 204:
             log.error(
                 "Error locking FileUploadBox ID %s in external service.",
                 box_id,
@@ -346,23 +361,38 @@ class FileBoxClient(FileBoxClientPort):
             )
             raise self.OperationError("Failed to lock FileUploadBox.")
 
-    async def unlock_file_upload_box(self, *, box_id: UUID4) -> None:
+    async def unlock_file_upload_box(self, *, box_id: UUID4, version: int) -> None:
         """Unlock a FileUploadBox in the owning service.
 
         Raises:
+            FUBVersionError if the remote box version differs from `version`.
             OperationError if there's a problem with the operation.
         """
         wot = ChangeFileBoxWorkOrder(work_type="unlock", box_id=box_id)
 
         headers = self._auth_header(wot)
-        body = {"lock": False}
+        body = {"version": version, "state": "open"}
         response = await self._client.patch(
             f"{self._ucs_url}/boxes/{box_id}",
             headers=headers,
             json=body,
             timeout=HTTPX_TIMEOUT,
         )
-        if response.status_code != 204:
+        if response.status_code == 409:
+            log.error(
+                "Failed to archive FileUploadBox %s because the version specified"
+                + " in the request is out of date.",
+                box_id,
+                extra={
+                    "box_id": box_id,
+                    "version": version,
+                    "response_text": response.text,
+                },
+            )
+            raise self.FUBVersionError(
+                "Requested FileUploadBox version is out of date."
+            )
+        elif response.status_code != 204:
             log.error(
                 "Error unlocking FileUploadBox ID %s in external service.",
                 box_id,
@@ -417,7 +447,7 @@ class FileBoxClient(FileBoxClientPort):
         """
         wot = ChangeFileBoxWorkOrder(work_type="archive", box_id=box_id)
         headers = self._auth_header(wot)
-        body = {"version": version}
+        body = {"version": version, "state": "archived"}
         response = await self._client.patch(
             f"{self._ucs_url}/boxes/{box_id}",
             headers=headers,

--- a/src/uos/core/orchestrator.py
+++ b/src/uos/core/orchestrator.py
@@ -235,9 +235,13 @@ class UploadOrchestrator(UploadOrchestratorPort):
         fub_id = updated_box.file_upload_box_id
         match (old_box.state, updated_box.state):
             case ("open", "locked"):  # lock the box
-                await self._file_upload_box_client.lock_file_upload_box(box_id=fub_id)
+                await self._file_upload_box_client.lock_file_upload_box(
+                    box_id=fub_id, version=updated_box.file_upload_box_version
+                )
             case ("locked", "open"):  # unlock the box
-                await self._file_upload_box_client.unlock_file_upload_box(box_id=fub_id)
+                await self._file_upload_box_client.unlock_file_upload_box(
+                    box_id=fub_id, version=updated_box.file_upload_box_version
+                )
             case ("locked", "archived"):  # archive the box
                 # Check prerequisites using old version number for logging purposes
                 await self._check_archival_prerequisites(box=old_box)

--- a/src/uos/ports/outbound/http.py
+++ b/src/uos/ports/outbound/http.py
@@ -115,19 +115,21 @@ class FileBoxClientPort(ABC):
         ...
 
     @abstractmethod
-    async def lock_file_upload_box(self, *, box_id: UUID4) -> None:
+    async def lock_file_upload_box(self, *, box_id: UUID4, version: int) -> None:
         """Lock a FileUploadBox in the owning service.
 
         Raises:
+            FUBVersionError if the remote box version differs from `version`.
             OperationError if there's a problem with the operation.
         """
         ...
 
     @abstractmethod
-    async def unlock_file_upload_box(self, *, box_id: UUID4) -> None:
+    async def unlock_file_upload_box(self, *, box_id: UUID4, version: int) -> None:
         """Unlock a FileUploadBox in the owning service.
 
         Raises:
+            FUBVersionError if the remote box version differs from `version`.
             OperationError if there's a problem with the operation.
         """
         ...

--- a/tests/unit/test_file_box_client.py
+++ b/tests/unit/test_file_box_client.py
@@ -15,6 +15,7 @@
 
 """Unit tests for the file box client"""
 
+import json
 from uuid import UUID, uuid4
 
 import httpx
@@ -62,13 +63,21 @@ async def test_lock_file_upload_box(
     )
     httpx_mock.add_response(204)
     await file_upload_box_client.lock_file_upload_box(
-        box_id=TEST_BOX_ID
+        box_id=TEST_BOX_ID, version=0
     )  # no error == success
+    assert json.loads(httpx_mock.get_requests()[0].content) == {
+        "version": 0,
+        "state": "locked",
+    }
+
+    httpx_mock.add_response(409, json="Box out of date")
+    with pytest.raises(FileBoxClient.FUBVersionError):
+        await file_upload_box_client.lock_file_upload_box(box_id=TEST_BOX_ID, version=0)
 
     # Check off-normal status code
     httpx_mock.add_response(500, json="Some error occurred.")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.lock_file_upload_box(box_id=TEST_BOX_ID)
+        await file_upload_box_client.lock_file_upload_box(box_id=TEST_BOX_ID, version=0)
 
 
 async def test_unlock_file_upload_box(
@@ -80,13 +89,25 @@ async def test_unlock_file_upload_box(
     )
     httpx_mock.add_response(204)
     await file_upload_box_client.unlock_file_upload_box(
-        box_id=TEST_BOX_ID
+        box_id=TEST_BOX_ID, version=0
     )  # no error == success
+    assert json.loads(httpx_mock.get_requests()[0].content) == {
+        "version": 0,
+        "state": "open",
+    }
+
+    httpx_mock.add_response(409, json="Box out of date")
+    with pytest.raises(FileBoxClient.FUBVersionError):
+        await file_upload_box_client.unlock_file_upload_box(
+            box_id=TEST_BOX_ID, version=0
+        )
 
     # Check off-normal status code
     httpx_mock.add_response(500, json="Some error occurred.")
     with pytest.raises(FileBoxClient.OperationError):
-        await file_upload_box_client.unlock_file_upload_box(box_id=TEST_BOX_ID)
+        await file_upload_box_client.unlock_file_upload_box(
+            box_id=TEST_BOX_ID, version=0
+        )
 
 
 async def test_get_file_upload_list(
@@ -131,3 +152,33 @@ async def test_get_file_upload_list(
     httpx_mock.add_response(200, json=[])
     file_list = await file_upload_box_client.get_file_upload_list(box_id=TEST_BOX_ID)
     assert file_list == []
+
+
+async def test_archive_file_upload_box(
+    config: ConfigFixture, httpx_mock: HTTPXMock, httpx_client: httpx.AsyncClient
+):
+    """Test the archive_file_upload_box function"""
+    file_upload_box_client = FileBoxClient(
+        config=config.config, httpx_client=httpx_client
+    )
+    httpx_mock.add_response(204)
+    await file_upload_box_client.archive_file_upload_box(
+        box_id=TEST_BOX_ID, version=0
+    )  # no error == success
+    assert json.loads(httpx_mock.get_requests()[0].content) == {
+        "version": 0,
+        "state": "archived",
+    }
+
+    httpx_mock.add_response(409, json="Box out of date")
+    with pytest.raises(FileBoxClient.FUBVersionError):
+        await file_upload_box_client.archive_file_upload_box(
+            box_id=TEST_BOX_ID, version=0
+        )
+
+    # Check off-normal status code
+    httpx_mock.add_response(500, json="Some error occurred.")
+    with pytest.raises(FileBoxClient.OperationError):
+        await file_upload_box_client.archive_file_upload_box(
+            box_id=TEST_BOX_ID, version=0
+        )


### PR DESCRIPTION
In the previous PR I forgot to update the request bodies for lock/unlock requests, and didn't have a dedicated test for the archive endpoint. This adds those things.