### PR TITLE
Fix status code expected when granting box access

### DIFF
--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -71,7 +71,6 @@ class AccessClient(AccessClientPort):
     """An adapter for interacting with the access API to manage upload access grants"""
 
     def __init__(self, *, config: AccessApiConfig, httpx_client: httpx.AsyncClient):
-        self._access_url = config.access_url
         self._access_url = str(config.access_url).rstrip("/")
         self._client = httpx_client
 
@@ -272,7 +271,6 @@ class FileBoxClient(FileBoxClientPort):
     """
 
     def __init__(self, *, config: FileBoxClientConfig, httpx_client: httpx.AsyncClient):
-        self._ucs_url = config.ucs_url
         self._ucs_url = str(config.ucs_url).rstrip("/")
         self._client = httpx_client
         self._signing_key = jwk.JWK.from_json(
@@ -502,7 +500,7 @@ class AccessionClient(AccessionClientPort):
         self, *, config: AccessionClientConfig, httpx_client: httpx.AsyncClient
     ):
         self._client = httpx_client
-        self._accession_url = config.accession_url
+        self._accession_url = str(config.accession_url).rstrip("/")
         self._signing_key = jwk.JWK.from_json(
             config.work_order_signing_key.get_secret_value()
         )

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -72,6 +72,7 @@ class AccessClient(AccessClientPort):
 
     def __init__(self, *, config: AccessApiConfig, httpx_client: httpx.AsyncClient):
         self._access_url = config.access_url
+        self._access_url = str(config.access_url).rstrip("/")
         self._client = httpx_client
 
     async def grant_upload_access(

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -98,7 +98,7 @@ class AccessClient(AccessClientPort):
         }
 
         response = await self._client.post(url, json=body, timeout=HTTPX_TIMEOUT)
-        if response.status_code != 200:
+        if response.status_code != 204:
             log.error(
                 "Failed to grant upload access for user %s to box %s.",
                 user_id,

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -273,6 +273,7 @@ class FileBoxClient(FileBoxClientPort):
 
     def __init__(self, *, config: FileBoxClientConfig, httpx_client: httpx.AsyncClient):
         self._ucs_url = config.ucs_url
+        self._ucs_url = str(config.ucs_url).rstrip("/")
         self._client = httpx_client
         self._signing_key = jwk.JWK.from_json(
             config.work_order_signing_key.get_secret_value()

--- a/tests/integration/test_typical_journey.py
+++ b/tests/integration/test_typical_journey.py
@@ -105,7 +105,7 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
     httpx_mock.add_response(
         method="POST",
         url=f"{access_url}/upload-access/users/{regular_user_id}/ivas/{iva_id}/boxes/{box_id}",
-        status_code=200,
+        status_code=204,
     )
     valid_from = now_utc_ms_prec()
     valid_until = now_utc_ms_prec() + timedelta(days=7)

--- a/tests/unit/test_access_client.py
+++ b/tests/unit/test_access_client.py
@@ -42,7 +42,7 @@ async def test_grant_upload_access(
     access_client = AccessClient(config=config.config, httpx_client=httpx_client)
 
     # Happy path
-    httpx_mock.add_response(200)
+    httpx_mock.add_response(204)
     await access_client.grant_upload_access(
         user_id=TEST_USER_ID,
         iva_id=TEST_IVA_ID,


### PR DESCRIPTION
The UOS was set up to expect a 200 status code and fail if it got anything else when creating an upload access grant to the CRS. The CRS, however, returns a 204. So this PR fixes the UOS's expectation about the code.