### PR TITLE
Return ID of Created Access Grant(GSI-2211)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -184,6 +184,18 @@ components:
       - box_id
       title: GrantAccessRequest
       type: object
+    GrantId:
+      description: The ID of an access grant.
+      properties:
+        id:
+          description: Internal grant ID (same as claim ID)
+          format: uuid4
+          title: Id
+          type: string
+      required:
+      - id
+      title: GrantId
+      type: object
     GrantWithBoxInfo:
       description: An UploadGrant with the ResearchDataUploadBox title and description.
       properties:
@@ -512,9 +524,7 @@ paths:
           content:
             application/json:
               schema:
-                format: uuid4
-                title: Response Grant Upload Access Access Grants Post
-                type: string
+                $ref: '#/components/schemas/GrantId'
           description: Upload access granted successfully.
         '401':
           description: Not authenticated.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -511,7 +511,10 @@ paths:
         '201':
           content:
             application/json:
-              schema: {}
+              schema:
+                format: uuid4
+                title: Response Grant Upload Access Access Grants Post
+                type: string
           description: Upload access granted successfully.
         '401':
           description: Not authenticated.

--- a/src/uos/adapters/inbound/fastapi_/routes.py
+++ b/src/uos/adapters/inbound/fastapi_/routes.py
@@ -270,10 +270,10 @@ async def grant_upload_access(
     request: GrantAccessRequest,
     upload_service: UploadOrchestratorDummy,
     auth_context: StewardAuthContext,
-):
+) -> UUID4:
     """Grant upload access to a user. Requires Data Steward role."""
     try:
-        await upload_service.grant_upload_access(
+        return await upload_service.grant_upload_access(
             user_id=request.user_id,
             iva_id=request.iva_id,
             box_id=request.box_id,
@@ -281,7 +281,6 @@ async def grant_upload_access(
             valid_until=request.valid_until,
             granting_user_id=UUID(auth_context.id),
         )
-        return {"message": "Upload access granted successfully"}
     except Exception as err:
         log.error(err, exc_info=True)
         raise HttpInternalError(message="Failed to grant upload access") from err

--- a/src/uos/adapters/inbound/fastapi_/routes.py
+++ b/src/uos/adapters/inbound/fastapi_/routes.py
@@ -38,6 +38,7 @@ from uos.core.models import (
     CreateUploadBoxRequest,
     FileUploadWithAccession,
     GrantAccessRequest,
+    GrantId,
     GrantWithBoxInfo,
     ResearchDataUploadBox,
     UpdateUploadBoxRequest,
@@ -146,7 +147,7 @@ async def get_research_data_upload_box(
     box_id: UUID,
     upload_service: UploadOrchestratorDummy,
     auth_context: UserAuthContext,
-):
+) -> ResearchDataUploadBox:
     """Get details of a specific upload box. If the user doesn't have access to an
     existing box, this endpoint will return a 404.
     """
@@ -270,7 +271,7 @@ async def grant_upload_access(
     request: GrantAccessRequest,
     upload_service: UploadOrchestratorDummy,
     auth_context: StewardAuthContext,
-) -> UUID4:
+) -> GrantId:
     """Grant upload access to a user. Requires Data Steward role."""
     try:
         return await upload_service.grant_upload_access(

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -100,7 +100,7 @@ class AccessClient(AccessClientPort):
         }
 
         response = await self._client.post(url, json=body, timeout=HTTPX_TIMEOUT)
-        if response.status_code != 204:
+        if response.status_code != 201:
             log.error(
                 "Failed to grant upload access for user %s to box %s.",
                 user_id,

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -82,8 +82,10 @@ class AccessClient(AccessClientPort):
         box_id: UUID4,
         valid_from: UTCDatetime,
         valid_until: UTCDatetime,
-    ) -> None:
+    ) -> UUID4:
         """Grant upload access to a user for a box.
+
+        Returns the created grant ID.
 
         Raises:
             AccessAPIError: if there's a problem during the operation.
@@ -114,6 +116,12 @@ class AccessClient(AccessClientPort):
                 },
             )
             raise self.AccessAPIError("Failed to grant upload access.")
+        try:
+            return UUID(response.json())
+        except Exception as err:
+            msg = "Failed to extract the ID of the newly created access grant from the response body."
+            log.error(msg, exc_info=True)
+            raise self.AccessAPIError(msg) from err
 
     async def revoke_upload_access(self, *, grant_id: UUID4) -> None:
         """Revoke a user's access to an upload box.

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -33,6 +33,7 @@ from uos.core.models import (
     ChangeFileBoxWorkOrder,
     CreateFileBoxWorkOrder,
     FileUploadWithAccession,
+    GrantId,
     SubmitAccessionMapWorkOrder,
     UploadGrant,
     ViewFileBoxWorkOrder,
@@ -82,7 +83,7 @@ class AccessClient(AccessClientPort):
         box_id: UUID4,
         valid_from: UTCDatetime,
         valid_until: UTCDatetime,
-    ) -> UUID4:
+    ) -> GrantId:
         """Grant upload access to a user for a box.
 
         Returns the created grant ID.
@@ -117,7 +118,7 @@ class AccessClient(AccessClientPort):
             )
             raise self.AccessAPIError("Failed to grant upload access.")
         try:
-            return UUID(response.json()["id"])
+            return GrantId(id=response.json()["id"])
         except Exception as err:
             msg = "Failed to extract the ID of the newly created access grant from the response body."
             log.error(msg, exc_info=True)

--- a/src/uos/adapters/outbound/http.py
+++ b/src/uos/adapters/outbound/http.py
@@ -117,7 +117,7 @@ class AccessClient(AccessClientPort):
             )
             raise self.AccessAPIError("Failed to grant upload access.")
         try:
-            return UUID(response.json())
+            return UUID(response.json()["id"])
         except Exception as err:
             msg = "Failed to extract the ID of the newly created access grant from the response body."
             log.error(msg, exc_info=True)

--- a/src/uos/core/models.py
+++ b/src/uos/core/models.py
@@ -148,6 +148,12 @@ class UpdateUploadBoxRequest(BaseModel):
     state: UploadBoxState | None = Field(default=None, description="Updated state")
 
 
+class GrantId(BaseModel):
+    """The ID of an access grant."""
+
+    id: UUID4 = Field(..., description="Internal grant ID (same as claim ID)")
+
+
 class GrantAccessRequest(BaseModel):
     """Request model for granting upload access to a user."""
 
@@ -167,10 +173,9 @@ class GrantAccessRequest(BaseModel):
         return value
 
 
-class UploadGrant(BaseModel):
+class UploadGrant(GrantId):
     """An upload access grant."""
 
-    id: UUID4 = Field(..., description="Internal grant ID (same as claim ID)")
     user_id: UUID4 = Field(..., description="Internal user ID")
     iva_id: UUID4 | None = Field(
         default=None, description="ID of an IVA associated with this grant"

--- a/src/uos/core/orchestrator.py
+++ b/src/uos/core/orchestrator.py
@@ -31,6 +31,7 @@ from uos.core.models import (
     BoxRetrievalResults,
     FileUploadBox,
     FileUploadWithAccession,
+    GrantId,
     GrantWithBoxInfo,
     ResearchDataUploadBox,
     UpdateUploadBoxRequest,
@@ -327,7 +328,7 @@ class UploadOrchestrator(UploadOrchestratorPort):
         valid_from: UTCDatetime,
         valid_until: UTCDatetime,
         granting_user_id: UUID4,
-    ) -> UUID4:
+    ) -> GrantId:
         """Grant upload access to a user for a specific research data upload box.
 
         Returns the created grant ID.

--- a/src/uos/core/orchestrator.py
+++ b/src/uos/core/orchestrator.py
@@ -327,8 +327,10 @@ class UploadOrchestrator(UploadOrchestratorPort):
         valid_from: UTCDatetime,
         valid_until: UTCDatetime,
         granting_user_id: UUID4,
-    ) -> None:
+    ) -> UUID4:
         """Grant upload access to a user for a specific research data upload box.
+
+        Returns the created grant ID.
 
         Raises:
             AccessAPIError: if there's a problem communicating with the access API.
@@ -339,7 +341,7 @@ class UploadOrchestrator(UploadOrchestratorPort):
         await self._box_dao.get_by_id(box_id)
 
         # Grant access via Claims Repository Service (errors handled by access client)
-        await self._access_client.grant_upload_access(
+        grant_id = await self._access_client.grant_upload_access(
             user_id=user_id,
             iva_id=iva_id,
             box_id=box_id,
@@ -352,6 +354,7 @@ class UploadOrchestrator(UploadOrchestratorPort):
         log.info(
             "Access grant operation successful for user %s and box %s", user_id, box_id
         )
+        return grant_id
 
     async def revoke_upload_access_grant(self, grant_id: UUID4) -> None:
         """Revoke a user's access to an upload box.

--- a/src/uos/ports/inbound/orchestrator.py
+++ b/src/uos/ports/inbound/orchestrator.py
@@ -26,6 +26,7 @@ from uos.core.models import (
     BoxRetrievalResults,
     FileUploadBox,
     FileUploadWithAccession,
+    GrantId,
     GrantWithBoxInfo,
     ResearchDataUploadBox,
     UpdateUploadBoxRequest,
@@ -131,7 +132,7 @@ class UploadOrchestratorPort(ABC):
         valid_from: UTCDatetime,
         valid_until: UTCDatetime,
         granting_user_id: UUID4,
-    ) -> UUID4:
+    ) -> GrantId:
         """Grant upload access to a user for a specific research data upload box.
 
         Returns the created grant ID.

--- a/src/uos/ports/inbound/orchestrator.py
+++ b/src/uos/ports/inbound/orchestrator.py
@@ -131,8 +131,10 @@ class UploadOrchestratorPort(ABC):
         valid_from: UTCDatetime,
         valid_until: UTCDatetime,
         granting_user_id: UUID4,
-    ) -> None:
+    ) -> UUID4:
         """Grant upload access to a user for a specific research data upload box.
+
+        Returns the created grant ID.
 
         Raises:
             AccessAPIError: if there's a problem communicating with the access API.

--- a/src/uos/ports/outbound/http.py
+++ b/src/uos/ports/outbound/http.py
@@ -20,7 +20,13 @@ from abc import ABC, abstractmethod
 from ghga_service_commons.utils.utc_dates import UTCDatetime
 from pydantic import UUID4
 
-from uos.core.models import PID, AccessionMap, FileUploadWithAccession, UploadGrant
+from uos.core.models import (
+    PID,
+    AccessionMap,
+    FileUploadWithAccession,
+    GrantId,
+    UploadGrant,
+)
 
 
 class AccessClientPort(ABC):
@@ -41,7 +47,7 @@ class AccessClientPort(ABC):
         box_id: UUID4,
         valid_from: UTCDatetime,
         valid_until: UTCDatetime,
-    ) -> UUID4:
+    ) -> GrantId:
         """Grant upload access to a user for a box.
 
         Returns the created grant ID.

--- a/src/uos/ports/outbound/http.py
+++ b/src/uos/ports/outbound/http.py
@@ -41,8 +41,10 @@ class AccessClientPort(ABC):
         box_id: UUID4,
         valid_from: UTCDatetime,
         valid_until: UTCDatetime,
-    ) -> None:
+    ) -> UUID4:
         """Grant upload access to a user for a box.
+
+        Returns the created grant ID.
 
         Raises:
             AccessAPIError: if there's a problem during the operation.

--- a/tests/integration/test_typical_journey.py
+++ b/tests/integration/test_typical_journey.py
@@ -102,14 +102,16 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
     assert box_event_recorder.recorded_events[0].payload["id"] == str(box_id)
 
     # Grant a user access to said box
+    test_grant_id = uuid4()
     httpx_mock.add_response(
         method="POST",
         url=f"{access_url}/upload-access/users/{regular_user_id}/ivas/{iva_id}/boxes/{box_id}",
         status_code=204,
+        json=str(test_grant_id),
     )
     valid_from = now_utc_ms_prec()
     valid_until = now_utc_ms_prec() + timedelta(days=7)
-    await orchestrator.grant_upload_access(
+    grant_id = await orchestrator.grant_upload_access(
         user_id=regular_user_id,
         iva_id=iva_id,
         box_id=box_id,
@@ -117,6 +119,7 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
         valid_until=valid_until,
         granting_user_id=ds_user_id,
     )
+    assert grant_id == test_grant_id
 
     # Update the title or description of the box by a DS (this bumps version to 1)
     update_request = UpdateUploadBoxRequest(

--- a/tests/integration/test_typical_journey.py
+++ b/tests/integration/test_typical_journey.py
@@ -107,7 +107,7 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
         method="POST",
         url=f"{access_url}/upload-access/users/{regular_user_id}/ivas/{iva_id}/boxes/{box_id}",
         status_code=201,
-        json=str(test_grant_id),
+        json={"id": str(test_grant_id)},
     )
     valid_from = now_utc_ms_prec()
     valid_until = now_utc_ms_prec() + timedelta(days=7)

--- a/tests/integration/test_typical_journey.py
+++ b/tests/integration/test_typical_journey.py
@@ -25,7 +25,7 @@ from hexkit.utils import now_utc_ms_prec
 from pytest_httpx import HTTPXMock
 
 from tests.fixtures.joint import JointFixture
-from uos.core.models import AccessionMapRequest, UpdateUploadBoxRequest
+from uos.core.models import AccessionMapRequest, GrantId, UpdateUploadBoxRequest
 
 pytestmark = pytest.mark.asyncio
 
@@ -119,7 +119,7 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
         valid_until=valid_until,
         granting_user_id=ds_user_id,
     )
-    assert grant_id == test_grant_id
+    assert grant_id == GrantId(id=test_grant_id)
 
     # Update the title or description of the box by a DS (this bumps version to 1)
     update_request = UpdateUploadBoxRequest(

--- a/tests/integration/test_typical_journey.py
+++ b/tests/integration/test_typical_journey.py
@@ -106,7 +106,7 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
     httpx_mock.add_response(
         method="POST",
         url=f"{access_url}/upload-access/users/{regular_user_id}/ivas/{iva_id}/boxes/{box_id}",
-        status_code=204,
+        status_code=201,
         json=str(test_grant_id),
     )
     valid_from = now_utc_ms_prec()

--- a/tests/unit/test_access_client.py
+++ b/tests/unit/test_access_client.py
@@ -43,7 +43,7 @@ async def test_grant_upload_access(
 
     # Happy path
     test_grant_id = uuid4()
-    httpx_mock.add_response(204, json=str(test_grant_id))
+    httpx_mock.add_response(201, json=str(test_grant_id))
     result = await access_client.grant_upload_access(
         user_id=TEST_USER_ID,
         iva_id=TEST_IVA_ID,
@@ -54,7 +54,7 @@ async def test_grant_upload_access(
     assert result == test_grant_id
 
     # Check bad response body (not a valid UUID)
-    httpx_mock.add_response(204, json="not-a-uuid")
+    httpx_mock.add_response(201, json="not-a-uuid")
     with pytest.raises(AccessClient.AccessAPIError):
         await access_client.grant_upload_access(
             user_id=TEST_USER_ID,

--- a/tests/unit/test_access_client.py
+++ b/tests/unit/test_access_client.py
@@ -25,6 +25,7 @@ from pytest_httpx import HTTPXMock
 
 from tests.fixtures import ConfigFixture
 from uos.adapters.outbound.http import AccessClient
+from uos.core.models import GrantId
 
 pytestmark = pytest.mark.asyncio
 
@@ -51,7 +52,7 @@ async def test_grant_upload_access(
         valid_from=VALID_FROM,
         valid_until=VALID_UNTIL,
     )
-    assert result == test_grant_id
+    assert result == GrantId(id=test_grant_id)
 
     # Check bad response body (not a valid UUID)
     httpx_mock.add_response(201, json={"id": "not-a-uuid"})

--- a/tests/unit/test_access_client.py
+++ b/tests/unit/test_access_client.py
@@ -43,7 +43,7 @@ async def test_grant_upload_access(
 
     # Happy path
     test_grant_id = uuid4()
-    httpx_mock.add_response(201, json=str(test_grant_id))
+    httpx_mock.add_response(201, json={"id": str(test_grant_id)})
     result = await access_client.grant_upload_access(
         user_id=TEST_USER_ID,
         iva_id=TEST_IVA_ID,
@@ -54,7 +54,7 @@ async def test_grant_upload_access(
     assert result == test_grant_id
 
     # Check bad response body (not a valid UUID)
-    httpx_mock.add_response(201, json="not-a-uuid")
+    httpx_mock.add_response(201, json={"id": "not-a-uuid"})
     with pytest.raises(AccessClient.AccessAPIError):
         await access_client.grant_upload_access(
             user_id=TEST_USER_ID,

--- a/tests/unit/test_access_client.py
+++ b/tests/unit/test_access_client.py
@@ -42,14 +42,27 @@ async def test_grant_upload_access(
     access_client = AccessClient(config=config.config, httpx_client=httpx_client)
 
     # Happy path
-    httpx_mock.add_response(204)
-    await access_client.grant_upload_access(
+    test_grant_id = uuid4()
+    httpx_mock.add_response(204, json=str(test_grant_id))
+    result = await access_client.grant_upload_access(
         user_id=TEST_USER_ID,
         iva_id=TEST_IVA_ID,
         box_id=TEST_BOX_ID,
         valid_from=VALID_FROM,
         valid_until=VALID_UNTIL,
-    )  # no error == success
+    )
+    assert result == test_grant_id
+
+    # Check bad response body (not a valid UUID)
+    httpx_mock.add_response(204, json="not-a-uuid")
+    with pytest.raises(AccessClient.AccessAPIError):
+        await access_client.grant_upload_access(
+            user_id=TEST_USER_ID,
+            iva_id=TEST_IVA_ID,
+            box_id=TEST_BOX_ID,
+            valid_from=VALID_FROM,
+            valid_until=VALID_UNTIL,
+        )
 
     # Check off-normal status code
     httpx_mock.add_response(500, json={"error": "Some error occurred."})

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -356,12 +356,13 @@ async def test_grant_upload_access(
         assert response.status_code == 403
 
         # normal response with data steward role
-        orchestrator.grant_upload_access.return_value = None
+        test_grant_id = uuid4()
+        orchestrator.grant_upload_access.return_value = test_grant_id
         response = await rest_client.post(
             url, json=request_data, headers=ds_auth_headers
         )
         assert response.status_code == 201
-        assert response.json() == {"message": "Upload access granted successfully"}
+        assert response.json() == str(test_grant_id)
 
         # handle other exception
         orchestrator.reset_mock()

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -27,6 +27,7 @@ from tests.fixtures import ConfigFixture
 from uos.core.models import (
     BoxRetrievalResults,
     FileUploadWithAccession,
+    GrantId,
     GrantWithBoxInfo,
     ResearchDataUploadBox,
 )
@@ -357,12 +358,12 @@ async def test_grant_upload_access(
 
         # normal response with data steward role
         test_grant_id = uuid4()
-        orchestrator.grant_upload_access.return_value = test_grant_id
+        orchestrator.grant_upload_access.return_value = GrantId(id=test_grant_id)
         response = await rest_client.post(
             url, json=request_data, headers=ds_auth_headers
         )
         assert response.status_code == 201
-        assert response.json() == str(test_grant_id)
+        assert response.json() == {"id": str(test_grant_id)}
 
         # handle other exception
         orchestrator.reset_mock()


### PR DESCRIPTION
Updates UOS so it returns the ID of the created access grant when giving a user upload access to a ResearchDataUploadBox.